### PR TITLE
RxSwift completely removed from tests

### DIFF
--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
@@ -15,13 +15,13 @@ class createAssociatedTokenAccount: XCTestCase {
     
     func testGetOrCreateAssociatedTokenAccount() {
         let tokenMint = PublicKey(string: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!
-        let account: (transactionId: TransactionID?, associatedTokenAddress: PublicKey)? = try! solana.action.getOrCreateAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint).get()
+        let account: (transactionId: TransactionID?, associatedTokenAddress: PublicKey)? = try! solana.action.getOrCreateAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint)?.get()
         XCTAssertNotNil(account)
     }
     
     func testFailCreateAssociatedTokenAccountItExisted() {
         let tokenMint = PublicKey(string: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!
-        XCTAssertThrowsError(try (solana.action.createAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint).get() as TransactionID?))
+        XCTAssertThrowsError(try (solana.action.createAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint)?.get() as TransactionID?))
     }
 
     func testFindAssociatedTokenAddress() {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssosiatedTokenAccount+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssosiatedTokenAccount+SimpleLock.swift
@@ -12,44 +12,34 @@ extension Action {
     public func getOrCreateAssociatedTokenAccount(
         for owner: PublicKey,
         tokenMint: PublicKey
-    ) -> Result<(transactionId: TransactionID?, associatedTokenAddress: PublicKey), Error> {
+    ) -> Result<(transactionId: TransactionID?, associatedTokenAddress: PublicKey), Error>? {
         var info: Result<(transactionId: TransactionID?, associatedTokenAddress: PublicKey), Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.getOrCreateAssociatedTokenAccount(owner: owner, tokenMint: tokenMint) {
-                switch $0 {
-                case .success(let result):
-                    info = .success(result)
-                case .failure(let error):
-                    info = .failure(error)
-                }
+                info = $0
                 lock.stop()
             }
         }
         lock.run()
-        return info!
+        return info
     }
 
     public func createAssociatedTokenAccount(
         for owner: PublicKey,
         tokenMint: PublicKey,
         payer: Account? = nil
-    ) -> Result<TransactionID?, Error> {
-        var transactionId: Result<TransactionID?, Error>?
+    ) -> Result<TransactionID, Error>? {
+        var transactionId: Result<TransactionID, Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.createAssociatedTokenAccount(for: owner, tokenMint: tokenMint, payer: payer) {
-                switch $0 {
-                case .success(let bufferInfo):
-                    transactionId = .success(bufferInfo)
-                case .failure(let error):
-                    transactionId = .failure(error)
-                }
+                transactionId = $0
                 lock.stop()
             }
         }
         lock.run()
-        return transactionId!
+        return transactionId
     }
 }
 

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount+SimpleLock.swift
@@ -15,12 +15,7 @@ extension Action {
         let lock = RunLoopSimpleLock()
         lock.dispatch {
             self.createTokenAccount(mintAddress: mintAddress) {
-                switch $0 {
-                case .success(let transaction):
-                    transactionResult = .success(transaction)
-                case .failure(let error):
-                    transactionResult = .failure(error)
-                }
+                transactionResult = $0
                 lock.stop()
             }
         }

--- a/Tests/SolanaTests/Actions/getMintData/getMintData+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/getMintData/getMintData+SimpleLock.swift
@@ -15,12 +15,7 @@ extension Action {
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.getMintData(mintAddress: mintAddress, programId: programId) { result in
-                switch result {
-                case .success(let mint):
-                    mintResult = .success(mint)
-                case .failure(let error):
-                    mintResult = .failure(error)
-                }
+                mintResult = result
                 lock.stop()
             }
         }
@@ -33,12 +28,7 @@ extension Action {
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.getMultipleMintDatas(mintAddresses: mintAddresses, programId: programId) { result in
-                switch result {
-                case .success(let mint):
-                    mintResult = .success(mint)
-                case .failure(let error):
-                    mintResult = .failure(error)
-                }
+                mintResult = result
                 lock.stop()
             }
         }
@@ -51,12 +41,7 @@ extension Action {
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.getPools(swapProgramId: "SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8") { result in
-                switch result {
-                case .success(let pools):
-                    resultPools = .success(pools)
-                case .failure(let error):
-                    resultPools = .failure(error)
-                }
+                resultPools = result
                 lock.stop()
             }
         }

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets+SimpleLock.swift
@@ -1,0 +1,25 @@
+//
+//  getTokenWallets+SimpleLock.swift
+//  
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension Action {
+    func getTokenWallets(account: String? = nil) -> Result<[Wallet], Error>? {
+        var walletResult: Result<[Wallet], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenWallets(account: account) { result in
+                walletResult = result
+                lock.stop()
+            }
+        }
+        lock.run()
+        return walletResult
+        
+    }
+}

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
@@ -1,7 +1,5 @@
 import XCTest
-import RxSwift
-import RxBlocking
-@testable import Solana
+import Solana
 
 class getTokenWallets: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
@@ -16,7 +14,7 @@ class getTokenWallets: XCTestCase {
     }
     
     func testsGetTokenWallets() {
-        let wallets = try! solana.action.getTokenWallets().toBlocking().first()
+        let wallets = try? solana.action.getTokenWallets()?.get()
         XCTAssertNotNil(wallets)
     }
 }

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL+SimpleLock.swift
@@ -1,0 +1,44 @@
+//
+//  sendSOL+SimpleLock.swift
+//  
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension Api {
+    func getBalance(account: String? = nil, commitment: Commitment? = nil) -> Result<UInt64, Error>? {
+        var balance: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getBalance(account: account, commitment: commitment) {
+                balance = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return balance
+    }
+}
+
+extension Action {
+
+    func sendSOL(
+        to destination: String,
+        amount: UInt64
+    ) -> Result<TransactionID, Error>? {
+        var transaction: Result<TransactionID, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.sendSOL(to: destination, amount: amount) {
+                transaction = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return transaction
+    }
+
+}

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
@@ -1,7 +1,5 @@
 import XCTest
-import RxSwift
-import RxBlocking
-@testable import Solana
+import Solana
 
 class sendSOL: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
@@ -18,13 +16,13 @@ class sendSOL: XCTestCase {
     func testSendSOLFromBalance() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance().toBlocking().first()
+        let balance = try! solana.api.getBalance()?.get()
         XCTAssertNotNil(balance)
 
         let transactionId = try! solana.action.sendSOL(
             to: toPublicKey,
             amount: balance!/10
-        ).toBlocking().first()
+        )?.get()
         XCTAssertNotNil(transactionId)
     }
     func testSendSOL() {
@@ -32,7 +30,7 @@ class sendSOL: XCTestCase {
         let transactionId = try! solana.action.sendSOL(
             to: toPublicKey,
             amount: 0.001.toLamport(decimals: 9)
-        ).toBlocking().first()
+        )?.get()
         XCTAssertNotNil(transactionId)
     }
     func testSendSOLIncorrectDestination() {
@@ -40,13 +38,13 @@ class sendSOL: XCTestCase {
         XCTAssertThrowsError(try solana.action.sendSOL(
             to: toPublicKey,
             amount: 0.001.toLamport(decimals: 9)
-        ).toBlocking().first())
+        )?.get())
     }
     func testSendSOLBigAmmount() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
         XCTAssertThrowsError(try solana.action.sendSOL(
             to: toPublicKey,
             amount: 9223372036854775808
-        ).toBlocking().first())
+        )?.get())
     }
 }

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
@@ -1,0 +1,49 @@
+//
+//  sendSPLTokens+SimpleLock.swift
+//  
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension Api {
+    func requestAirdrop(account: String, lamports: UInt64, commitment: Commitment? = nil) -> Result<String, Error>? {
+        var airdrop: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.requestAirdrop(account: account, lamports: lamports, commitment: commitment) {
+                airdrop = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return airdrop
+    }
+}
+
+extension Action {
+    public func sendSPLTokens(
+        mintAddress: String,
+        decimals: Decimals,
+        from fromPublicKey: String,
+        to destinationAddress: String,
+        amount: UInt64
+    ) -> Result<TransactionID, Error>? {
+        var transaction: Result<TransactionID, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.sendSPLTokens(mintAddress: mintAddress,
+                                decimals: decimals,
+                                from: fromPublicKey,
+                                to: destinationAddress,
+                                amount: amount) {
+                transaction = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return transaction
+    }
+}

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -1,7 +1,5 @@
 import XCTest
-import RxSwift
-import RxBlocking
-@testable import Solana
+import Solana
 
 class sendSPLTokens: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
@@ -13,7 +11,7 @@ class sendSPLTokens: XCTestCase {
         solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
         let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
         try solana.auth.save(account).get()
-        _ = try solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 100.toLamport(decimals: 9)).toBlocking().first()
+        _ = try solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 100.toLamport(decimals: 9))?.get()
     }
     
     func testSendSPLTokenWithFee() {
@@ -27,7 +25,7 @@ class sendSPLTokens: XCTestCase {
             from: source,
             to: destination,
             amount: Double(0.001).toLamport(decimals: 5)
-        ).toBlocking().first()
+        )?.get()
         XCTAssertNotNil(transactionId)
         
         let transactionIdB = try! solana.action.sendSPLTokens(
@@ -36,7 +34,7 @@ class sendSPLTokens: XCTestCase {
             from: destination,
             to: source,
             amount: Double(0.001).toLamport(decimals: 5)
-        ).toBlocking().first()
+        )?.get()
         XCTAssertNotNil(transactionIdB)
     }
 }

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee+SimpleLock.swift
@@ -1,0 +1,56 @@
+//
+//  serializeAndSendWithFee+SimpleLock.swift
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension Action {
+    func serializeAndSendWithFee(
+        instructions: [TransactionInstruction],
+        recentBlockhash: String? = nil,
+        signers: [Account],
+        maxAttemps: Int = 3,
+        numberOfTries: Int = 0
+    ) -> Result<String, Error>? {
+        var transaction: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.serializeAndSendWithFee(instructions: instructions,
+                                          recentBlockhash: recentBlockhash,
+                                          signers: signers,
+                                          maxAttemps: maxAttemps,
+                                          numberOfTries: numberOfTries) {
+                transaction = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return transaction
+    }
+    
+    func serializeAndSendWithFeeSimulation(
+        instructions: [TransactionInstruction],
+        recentBlockhash: String? = nil,
+        signers: [Account],
+        maxAttemps: Int = 3,
+        numberOfTries: Int = 0
+    ) -> Result<String, Error>? {
+        var transaction: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.serializeAndSendWithFeeSimulation(instructions: instructions,
+                                                    recentBlockhash: recentBlockhash,
+                                                    signers: signers,
+                                                    maxAttemps: maxAttemps,
+                                                    numberOfTries: numberOfTries) {
+                transaction = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return transaction
+    }
+}

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
@@ -1,6 +1,4 @@
 import XCTest
-import RxSwift
-import RxBlocking
 @testable import Solana
 
 class serializeAndSendWithFee: XCTestCase {
@@ -18,7 +16,7 @@ class serializeAndSendWithFee: XCTestCase {
     func testSimulationSerializeAndSend() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance().toBlocking().first()
+        let balance = try! solana.api.getBalance()?.get()
         XCTAssertNotNil(balance)
 
         let instruction = SystemProgram.transferInstruction(
@@ -27,14 +25,14 @@ class serializeAndSendWithFee: XCTestCase {
             lamports: 0.001.toLamport(decimals: 9)
         )
         
-        let transactionId = try! solana.action.serializeAndSendWithFeeSimulation(instructions: [instruction], signers: [account]).toBlocking().first()
+        let transactionId = try! solana.action.serializeAndSendWithFeeSimulation(instructions: [instruction], signers: [account])?.get()
         XCTAssertNotNil(transactionId)
     }
     
     func testSerializeAndSend() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance().toBlocking().first()
+        let balance = try! solana.api.getBalance()?.get()
         XCTAssertNotNil(balance)
 
         let instruction = SystemProgram.transferInstruction(
@@ -43,7 +41,7 @@ class serializeAndSendWithFee: XCTestCase {
             lamports: 0.001.toLamport(decimals: 9)
         )
         
-        let transactionId = try! solana.action.serializeAndSendWithFee( instructions: [instruction], signers: [account]).toBlocking().first()
+        let transactionId = try! solana.action.serializeAndSendWithFee( instructions: [instruction], signers: [account])?.get()
         XCTAssertNotNil(transactionId)
     }
     

--- a/Tests/SolanaTests/Actions/swap/swap.swift
+++ b/Tests/SolanaTests/Actions/swap/swap.swift
@@ -1,6 +1,4 @@
 import XCTest
-import RxSwift
-import RxBlocking
 @testable import Solana
 
 class swap: XCTestCase {

--- a/Tests/SolanaTests/Api/Methods+SimpleLock.swift
+++ b/Tests/SolanaTests/Api/Methods+SimpleLock.swift
@@ -1,0 +1,502 @@
+//
+//  Methods+SimpleLock.swift
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension Api {
+    func getAccountInfo<T: BufferLayout>(account: String, decodedTo: T.Type) -> Result<BufferInfo<T>, Error>? {
+        var result: Result<BufferInfo<T>, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getAccountInfo(account: account, decodedTo: decodedTo) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getMultipleAccounts<T: BufferLayout>(pubkeys: [String], decodedTo: T.Type) -> Result<[BufferInfo<T>], Error>? {
+        var result: Result<[BufferInfo<T>], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getMultipleAccounts(pubkeys: pubkeys, decodedTo: decodedTo) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    func getProgramAccounts<T: BufferLayout>(publicKey: String, configs: RequestConfiguration? = RequestConfiguration(encoding: "base64"), decodedTo: T.Type) -> Result<[ProgramAccount<T>], Error>? {
+        var result: Result<[ProgramAccount<T>], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getProgramAccounts(publicKey: publicKey, configs: configs, decodedTo: decodedTo) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    func getBlockCommitment(block: UInt64) -> Result<BlockCommitment, Error>? {
+        var result: Result<BlockCommitment, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getBlockCommitment(block: block) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getClusterNodes() -> Result<[ClusterNodes], Error>? {
+        var result: Result<[ClusterNodes], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getClusterNodes {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getBlockTime(block: UInt64) -> Result<Date?, Error>? {
+        var result: Result<Date?, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getBlockTime(block: block) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getConfirmedBlock(slot: UInt64, encoding: String = "json") -> Result<ConfirmedBlock, Error>? {
+        var result: Result<ConfirmedBlock, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getConfirmedBlock(slot: slot, encoding: encoding) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getConfirmedBlocks(startSlot: UInt64, endSlot: UInt64) -> Result<[UInt64], Error>? {
+        var result: Result<[UInt64], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getConfirmedBlocks(startSlot: startSlot, endSlot: endSlot) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getConfirmedBlocksWithLimit(startSlot: UInt64, limit: UInt64) -> Result<[UInt64], Error>? {
+        var result: Result<[UInt64], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getConfirmedBlocksWithLimit(startSlot: startSlot, limit: limit) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getConfirmedSignaturesForAddress2(account: String, configs: RequestConfiguration? = nil) -> Result<[SignatureInfo], Error>? {
+        var result: Result<[SignatureInfo], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getConfirmedSignaturesForAddress2(account: account, configs: configs) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getConfirmedTransaction(transactionSignature: String) -> Result<TransactionInfo, Error>? {
+        var result: Result<TransactionInfo, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getConfirmedTransaction(transactionSignature: transactionSignature) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getEpochInfo(commitment: Commitment? = nil) -> Result<EpochInfo, Error>? {
+        var result: Result<EpochInfo, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getEpochInfo(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getEpochSchedule() -> Result<EpochSchedule, Error>? {
+        var result: Result<EpochSchedule, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getEpochSchedule {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getRecentBlockhash(commitment: Commitment? = nil) ->  Result<String, Error>? {
+        var result: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getRecentBlockhash(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getFeeRateGovernor() -> Result<Fee, Error>? {
+        var result: Result<Fee, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getFeeRateGovernor {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getFeeCalculatorForBlockhash(blockhash: String, commitment: Commitment? = nil) -> Result<Fee, Error>? {
+        var result: Result<Fee, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getFeeCalculatorForBlockhash(blockhash: blockhash, commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getFees(commitment: Commitment? = nil) -> Result<Fee, Error>? {
+        var result: Result<Fee, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getFees(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getFirstAvailableBlock() -> Result<UInt64, Error>? {
+        var result: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getFirstAvailableBlock {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getGenesisHash() -> Result<String, Error>? {
+        var result: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getGenesisHash {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getIdentity() -> Result<Identity, Error>? {
+        var result: Result<Identity, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getIdentity {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getVersion() -> Result<Version, Error>? {
+        var result: Result<Version, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getVersion {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getInflationGovernor(commitment: Commitment? = nil) -> Result<InflationGovernor, Error>? {
+        var result: Result<InflationGovernor, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getInflationGovernor(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getInflationRate() -> Result<InflationRate, Error>? {
+        var result: Result<InflationRate, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getInflationRate {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getLargestAccounts() -> Result<[LargestAccount], Error>? {
+        var result: Result<[LargestAccount], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getLargestAccounts {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getMinimumBalanceForRentExemption(dataLength: UInt64, commitment: Commitment? = "recent") -> Result<UInt64, Error>? {
+        var result: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getMinimumBalanceForRentExemption(dataLength: dataLength, commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getRecentPerformanceSamples(limit: UInt64) -> Result<[PerformanceSample], Error>? {
+        var result: Result<[PerformanceSample], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getRecentPerformanceSamples(limit: limit) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getVoteAccounts(commitment: Commitment? = nil) ->  Result<VoteAccounts, Error>? {
+        var result: Result<VoteAccounts, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getVoteAccounts(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func minimumLedgerSlot() -> Result<UInt64, Error>? {
+        var result: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.minimumLedgerSlot {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getSlot(commitment: Commitment? = nil) -> Result<UInt64, Error>? {
+        var result: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getSlot {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getSlotLeader(commitment: Commitment? = nil) -> Result<String, Error>? {
+        var result: Result<String, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getSlotLeader(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getTransactionCount(commitment: Commitment? = nil) -> Result<UInt64, Error>? {
+        var result: Result<UInt64, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTransactionCount(commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getStakeActivation(stakeAccount: String, configs: RequestConfiguration? = nil) -> Result<StakeActivation, Error>? {
+        var result: Result<StakeActivation, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getStakeActivation(stakeAccount: stakeAccount, configs: configs) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getSignatureStatuses(pubkeys: [String], configs: RequestConfiguration? = nil) -> Result<[SignatureStatus?], Error>? {
+        var result: Result<[SignatureStatus?], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getSignatureStatuses(pubkeys: pubkeys, configs: configs) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getTokenAccountBalance(pubkey: String, commitment: Commitment? = nil) -> Result<TokenAccountBalance, Error>? {
+        var result: Result<TokenAccountBalance, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenAccountBalance(pubkey: pubkey, commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getTokenAccountsByDelegate(pubkey: String, mint: String? = nil, programId: String? = nil, configs: RequestConfiguration? = nil) -> Result<[TokenAccount<AccountInfo>], Error>? {
+        var result: Result<[TokenAccount<AccountInfo>], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenAccountsByDelegate(pubkey: pubkey, mint: mint, programId: programId, configs: configs) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getTokenAccountsByOwner(pubkey: String, mint: String? = nil, programId: String? = nil, configs: RequestConfiguration? = nil) -> Result<[TokenAccount<AccountInfo>], Error>? {
+        var result: Result<[TokenAccount<AccountInfo>], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenAccountsByOwner(pubkey: pubkey, mint: mint, programId: programId, configs: configs) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+    
+    func getTokenSupply(pubkey: String, commitment: Commitment? = nil) -> Result<TokenAmount, Error>? {
+        var result: Result<TokenAmount, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenSupply(pubkey: pubkey, commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+
+    func getTokenLargestAccounts(pubkey: String, commitment: Commitment? = nil) -> Result<[TokenAmount], Error>? {
+        var result: Result<[TokenAmount], Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch { [weak self] in
+            self?.getTokenLargestAccounts(pubkey: pubkey, commitment: commitment) {
+                result = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return result
+    }
+}

--- a/Tests/SolanaTests/Api/Methods.swift
+++ b/Tests/SolanaTests/Api/Methods.swift
@@ -1,7 +1,4 @@
 import XCTest
-import RxSwift
-import RxBlocking
-import RxSolana
 @testable import Solana
 
 class Methods: XCTestCase {
@@ -17,82 +14,82 @@ class Methods: XCTestCase {
     }
 
     func testGetAccountInfo() {
-        let info: BufferInfo<AccountInfo>? = try! solana.api.getAccountInfo(account: "So11111111111111111111111111111111111111112", decodedTo: AccountInfo.self).toBlocking().first()
+        let info: BufferInfo<AccountInfo>? = try! solana.api.getAccountInfo(account: "So11111111111111111111111111111111111111112", decodedTo: AccountInfo.self)?.get()
         XCTAssertNotNil(info)
         XCTAssertNotNil(info?.data)
         XCTAssertTrue(info!.lamports > 0)
     }
     
     func testGetMultipleAccounts() {
-        let accounts: [BufferInfo<AccountInfo>?] = try! solana.api.getMultipleAccounts(pubkeys: ["skynetDj29GH6o6bAqoixCpDuYtWqi1rm8ZNx1hB3vq","namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX"], decodedTo: AccountInfo.self).toBlocking().first()!!
+        let accounts: [BufferInfo<AccountInfo>?] = try! solana.api.getMultipleAccounts(pubkeys: ["skynetDj29GH6o6bAqoixCpDuYtWqi1rm8ZNx1hB3vq","namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX"], decodedTo: AccountInfo.self)!.get()
         XCTAssertNotNil(accounts)
         XCTAssertTrue(accounts.count == 2)
         XCTAssertNotNil(accounts[0]?.data)
     }
     func testGetProgramAccounts() {
-        let info = try! solana.api.getProgramAccounts(publicKey: "SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8", decodedTo: TokenSwapInfo.self).toBlocking().first()
+        let info = try! solana.api.getProgramAccounts(publicKey: "SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8", decodedTo: TokenSwapInfo.self)?.get()
         XCTAssertNotNil(info)
     }
     func testGetBlockCommitment() {
-        let block = try! solana.api.getBlockCommitment(block: 82493733).toBlocking().first()
+        let block = try! solana.api.getBlockCommitment(block: 82493733)?.get()
         XCTAssertNotNil(block)
         XCTAssertTrue(block!.totalStake > 0)
     }
   
     func testGetBalance() {
-        let value = try! solana.api.getBalance(account: account.publicKey.base58EncodedString).toBlocking().first()
+        let value = try! solana.api.getBalance(account: account.publicKey.base58EncodedString)?.get()
         XCTAssertNotNil(value)
         XCTAssertTrue(value! > 0)
     }
     func testGetClusterNodes() {
-        let nodes = try! solana.api.getClusterNodes().toBlocking().first()
+        let nodes = try! solana.api.getClusterNodes()?.get()
         XCTAssertNotNil(nodes)
         XCTAssertTrue(nodes!.count > 0);
     }
     func testGetBlockTime() {
-        let date = try! solana.api.getBlockTime(block: 63426807).toBlocking().first()
+        let date = try! solana.api.getBlockTime(block: 63426807)?.get()
         XCTAssertNotNil(date!)
     }
     func testGetConfirmedBlock() {
-        let block = try! solana.api.getConfirmedBlock(slot: 63426807).toBlocking().first()
+        let block = try! solana.api.getConfirmedBlock(slot: 63426807)?.get()
         XCTAssertNotNil(block)
         XCTAssertEqual(63426806, block!.parentSlot);
     }
     func testGetConfirmedBlocks() {
-        let blocks = try! solana.api.getConfirmedBlocks(startSlot:63426807, endSlot: 63426808).toBlocking().first()
+        let blocks = try! solana.api.getConfirmedBlocks(startSlot:63426807, endSlot: 63426808)?.get()
         XCTAssertNotNil(blocks)
         XCTAssertEqual(blocks!.count, 2);
     }
     func testGetConfirmedBlocksWithLimit() {
-        let blocks = try! solana.api.getConfirmedBlocksWithLimit(startSlot:63426800, limit: 10).toBlocking().first()
+        let blocks = try! solana.api.getConfirmedBlocksWithLimit(startSlot:63426800, limit: 10)?.get()
         XCTAssertNotNil(blocks)
         XCTAssertEqual(blocks!.count, 10);
     }
     func testGetConfirmedSignaturesForAddress2() {
-        let result = try! solana.api.getConfirmedSignaturesForAddress2(account: "5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx", configs: RequestConfiguration(limit: 4)).toBlocking().first()
+        let result = try! solana.api.getConfirmedSignaturesForAddress2(account: "5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx", configs: RequestConfiguration(limit: 4))?.get()
         XCTAssertEqual(result?.count, 4)
     }
     func testGetConfirmedTransaction() {
-        let transaction = try! solana.api.getConfirmedTransaction(transactionSignature: "7Zk9yyJCXHapoKyHwd8AzPeW9fJWCvszR6VAcHUhvitN5W9QG9JRnoYXR8SBQPTh27piWEmdybchDt5j7xxoUth").toBlocking().first()
+        let transaction = try! solana.api.getConfirmedTransaction(transactionSignature: "7Zk9yyJCXHapoKyHwd8AzPeW9fJWCvszR6VAcHUhvitN5W9QG9JRnoYXR8SBQPTh27piWEmdybchDt5j7xxoUth")?.get()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.blockTime, 1623983206)
     }
     func testGetEpochInfo() {
-        let epoch = try! solana.api.getEpochInfo().toBlocking().first()
+        let epoch = try! solana.api.getEpochInfo()?.get()
         XCTAssertNotNil(epoch)
     }
     func testGetEpochSheadule() {
-        let epoch = try! solana.api.getEpochSchedule().toBlocking().first()
+        let epoch = try! solana.api.getEpochSchedule()?.get()
         XCTAssertNotNil(epoch)
     }
     func testGetFeeCalculatorForBlockhash() {
-        let hash = try! solana.api.getRecentBlockhash().toBlocking().first()
-        let fee = try! solana.api.getFeeCalculatorForBlockhash(blockhash: hash!).toBlocking().first()
+        let hash = try! solana.api.getRecentBlockhash()?.get()
+        let fee = try! solana.api.getFeeCalculatorForBlockhash(blockhash: hash!)?.get()
         XCTAssertNotNil(fee)
         XCTAssertTrue(fee!.feeCalculator!.lamportsPerSignature > 0)
     }
     func testGetFeeRateGovernor() {
-        let feeRateGovernorInfo = try! solana.api.getFeeRateGovernor().toBlocking().first()
+        let feeRateGovernorInfo = try! solana.api.getFeeRateGovernor()?.get()
         XCTAssertNotNil(feeRateGovernorInfo)
         
         XCTAssertTrue(feeRateGovernorInfo!.feeRateGovernor!.burnPercent > 0)
@@ -102,85 +99,85 @@ class Methods: XCTestCase {
         XCTAssertTrue(feeRateGovernorInfo!.feeRateGovernor!.targetSignaturesPerSlot >= 0)
     }
     func testGetFees() {
-        let feesInfo = try! solana.api.getFees().toBlocking().first()
+        let feesInfo = try! solana.api.getFees()?.get()
         XCTAssertNotNil(feesInfo)
         XCTAssertNotEqual("", feesInfo!.blockhash)
         XCTAssertTrue(feesInfo!.feeCalculator!.lamportsPerSignature > 0)
         XCTAssertTrue(feesInfo!.lastValidSlot! > 0)
     }
     func testGetFirstAvailableBlock() {
-        let block = try! solana.api.getFirstAvailableBlock().toBlocking().first()
+        let block = try! solana.api.getFirstAvailableBlock()?.get()
         XCTAssertNotNil(block)
         XCTAssertTrue(0 <= block!)
     }
     func testGetGenesisHash() {
-        let hash = try! solana.api.getGenesisHash().toBlocking().first()
+        let hash = try! solana.api.getGenesisHash()?.get()
         XCTAssertNotNil(hash)
     }
     func testGetIdentity() {
-        let identity = try! solana.api.getIdentity().toBlocking().first()
+        let identity = try! solana.api.getIdentity()?.get()
         XCTAssertNotNil(identity)
     }
     func testGetVersion() {
-        let version = try! solana.api.getVersion().toBlocking().first()
+        let version = try! solana.api.getVersion()?.get()
         XCTAssertNotNil(version)
     }
     /*func testRequestAirdrop() {
-        let airdrop = try! solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 10000000000).toBlocking().first()
+        let airdrop = try! solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 10000000000)?.get()
         XCTAssertNotNil(airdrop)
     }*/
     func testGetInflationGovernor() {
-        let governor = try! solana.api.getInflationGovernor().toBlocking().first()
+        let governor = try! solana.api.getInflationGovernor()?.get()
         XCTAssertNotNil(governor)
     }
     func testGetInflationRate() {
-        let rate = try! solana.api.getInflationRate().toBlocking().first()
+        let rate = try! solana.api.getInflationRate()?.get()
         XCTAssertNotNil(rate)
     }
     func testGetLargestAccounts() {
-        let accounts = try! solana.api.getLargestAccounts().toBlocking().first()
+        let accounts = try! solana.api.getLargestAccounts()?.get()
         XCTAssertNotNil(accounts)
     }
     // This tests is very expensive on time
     /*func testGetLeaderSchedule() {
-        let accounts = try! solana.api.getLeaderSchedule().toBlocking().first()
+        let accounts = try! solana.api.getLeaderSchedule()?.get()
         XCTAssertNotNil(accounts ?? nil)
     }*/
     func testGetMinimumBalanceForRentExemption() {
-        let accounts = try! solana.api.getMinimumBalanceForRentExemption(dataLength: 32000).toBlocking().first()
+        let accounts = try! solana.api.getMinimumBalanceForRentExemption(dataLength: 32000)?.get()
         XCTAssertNotNil(accounts)
     }
     func testGetRecentPerformanceSamples() {
-        let accounts = try! solana.api.getRecentPerformanceSamples(limit: 5).toBlocking().first()
+        let accounts = try! solana.api.getRecentPerformanceSamples(limit: 5)?.get()
         XCTAssertNotNil(accounts)
     }
     func testGetVoteAccounts() {
-        let accounts = try! solana.api.getVoteAccounts().toBlocking().first()
+        let accounts = try! solana.api.getVoteAccounts()?.get()
         XCTAssertNotNil(accounts)
     }
     func testGetRecentBlockhash() {
-        let accounts = try! solana.api.getRecentBlockhash().toBlocking().first()
+        let accounts = try! solana.api.getRecentBlockhash()?.get()
         XCTAssertNotNil(accounts)
     }
     func testMinimumLedgerSlot() {
-        let accounts = try! solana.api.minimumLedgerSlot().toBlocking().first()
+        let accounts = try! solana.api.minimumLedgerSlot()?.get()
         XCTAssertNotNil(accounts)
     }
     func testGetSlot() {
-        let slot = try! solana.api.getSlot().toBlocking().first()
+        let slot = try! solana.api.getSlot()?.get()
         XCTAssertNotNil(slot)
     }
     func testGetSlotLeader() {
-        let hash = try! solana.api.getSlotLeader().toBlocking().first()
+        let hash = try! solana.api.getSlotLeader()?.get()
         XCTAssertNotNil(hash)
     }
     func testGetTransactionCount() {
-        let count = try! solana.api.getTransactionCount().toBlocking().first()
+        let count = try! solana.api.getTransactionCount()?.get()
         XCTAssertNotNil(count)
     }
     func testGetStakeActivation() {
         // https://explorer.solana.com/address/HDDhNo3H2t3XbLmRswHdTu5L8SvSMypz9UVFu68Wgmaf?cluster=devnet
-        let stakeActivation = try! solana.api.getStakeActivation(stakeAccount: "HDDhNo3H2t3XbLmRswHdTu5L8SvSMypz9UVFu68Wgmaf").toBlocking().first()
+        let stakeActivation = try! solana.api.getStakeActivation(stakeAccount: "HDDhNo3H2t3XbLmRswHdTu5L8SvSMypz9UVFu68Wgmaf")?.get()
         XCTAssertNotNil(stakeActivation);
         XCTAssertEqual("active", stakeActivation!.state);
         XCTAssertTrue(stakeActivation!.active > 0);
@@ -188,7 +185,7 @@ class Methods: XCTestCase {
         XCTAssertNotNil(hash)
     }
     func testGetSignatureStatuses() {
-        let count = try! solana.api.getSignatureStatuses(pubkeys: ["3nVfYabxKv9ohGb4nXF3EyJQnbVcGVQAm2QKzdPrsemrP4D8UEZEzK8bCWgyTFif6mjo99akvHcCbxiEKzN5L9ZG"]).toBlocking().first()
+        let count = try! solana.api.getSignatureStatuses(pubkeys: ["3nVfYabxKv9ohGb4nXF3EyJQnbVcGVQAm2QKzdPrsemrP4D8UEZEzK8bCWgyTFif6mjo99akvHcCbxiEKzN5L9ZG"])?.get()
         XCTAssertNotNil(count)
 
     }
@@ -196,7 +193,7 @@ class Methods: XCTestCase {
     /* Tokens */
     func testGetTokenAccountBalance() {
         let tokenAddress = "FzhfekYF625gqAemjNZxjgTZGwfJpavMZpXCLFdypRFD"
-        let balance = try! solana.api.getTokenAccountBalance(pubkey: tokenAddress).toBlocking().first()
+        let balance = try! solana.api.getTokenAccountBalance(pubkey: tokenAddress)?.get()
         XCTAssertNotNil(balance?.uiAmount)
         XCTAssertNotNil(balance?.amount)
         XCTAssertNotNil(balance?.decimals)
@@ -204,24 +201,24 @@ class Methods: XCTestCase {
 
     func testGetTokenAccountsByDelegate() {
         let address = "AoUnMozL1ZF4TYyVJkoxQWfjgKKtu8QUK9L4wFdEJick"
-        let tokenAccount = try! solana.api.getTokenAccountsByDelegate(pubkey: address, programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").toBlocking().first()
+        let tokenAccount = try! solana.api.getTokenAccountsByDelegate(pubkey: address, programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")?.get()
         XCTAssertNotNil(tokenAccount)
         XCTAssertTrue(tokenAccount!.isEmpty);
     }
     
     func testGetTokenAccountsByOwner() {
         let address = "AoUnMozL1ZF4TYyVJkoxQWfjgKKtu8QUK9L4wFdEJick"
-        let balance = try! solana.api.getTokenAccountsByOwner(pubkey: address, mint: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8").toBlocking().first()
+        let balance = try! solana.api.getTokenAccountsByOwner(pubkey: address, mint: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")?.get()
         XCTAssertTrue(balance!.isEmpty)
     }
     func testGetTokenSupply() {
-        let tokenSupply = try! solana.api.getTokenSupply(pubkey: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8").toBlocking().first()!
+        let tokenSupply = try! solana.api.getTokenSupply(pubkey: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!.get()
         XCTAssertNotNil(tokenSupply)
         XCTAssertEqual(6, tokenSupply.decimals)
         XCTAssertTrue(tokenSupply.uiAmount > 0)
     }
     func testGetTokenLargestAccounts() {
-        let accounts = try! solana.api.getTokenLargestAccounts(pubkey: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8").toBlocking().first()!
+        let accounts = try! solana.api.getTokenLargestAccounts(pubkey: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!.get()
         XCTAssertNotNil(accounts[0])
     }
 }

--- a/Tests/SolanaTests/Models/PublicKey.swift
+++ b/Tests/SolanaTests/Models/PublicKey.swift
@@ -1,7 +1,5 @@
 import XCTest
-import RxSwift
-import RxBlocking
-@testable import Solana
+import Solana
 
 class PublicKeyTests: XCTestCase {
     
@@ -117,18 +115,6 @@ class PublicKeyTests: XCTestCase {
         XCTAssertEqual("QqCCvshxtqMAL2CVALqiJB7uEeE5mjSPsseQdDzsRUo", account.publicKey.base58EncodedString)
         XCTAssertEqual(64, account.secretKey.count)
     }
-// There is no "Keychain" entity
-//    #if canImport(UIKit)
-//    func testDerivedKeychain() {
-//        var keychain = try Keychain(seedString: "miracle pizza supply useful steak border same again youth silver access hundred", network: "mainnet-beta")
-//
-//        keychain = try keychain.derivedKeychain(at: "m/501'/0'/0/0")
-//
-//        let keys = try NaclSign.KeyPair.keyPair(fromSeed: keychain.privateKey!)
-//
-//        XCTAssertEqual([UInt8](keys.secretKey), [109, 13, 53, 177, 69, 45, 146, 184, 62, 55, 105, 133, 210, 89, 131, 218, 248, 101, 47, 64, 81, 56, 229, 25, 173, 154, 12, 41, 66, 143, 230, 117, 39, 247, 185, 4, 85, 137, 50, 166, 147, 184, 221, 75, 110, 103, 16, 222, 41, 94, 247, 132, 43, 62, 172, 243, 95, 204, 190, 143, 153, 16, 10, 197])
-//    }
-//    #endif
     
     func testRestoreAccountFromSeedPhrase() {
         let phrase12 = "miracle pizza supply useful steak border same again youth silver access hundred"

--- a/Tests/SolanaTests/RunLoopSimpleLock.swift
+++ b/Tests/SolanaTests/RunLoopSimpleLock.swift
@@ -18,11 +18,7 @@ import CoreFoundation
 #endif
 
 final class RunLoopSimpleLock {
-    let currentRunLoop: CFRunLoop
-
-    init() {
-        self.currentRunLoop = CFRunLoopGetCurrent()
-    }
+    let currentRunLoop = CFRunLoopGetCurrent()
 
     func dispatch(_ action: @escaping () -> Void) {
         CFRunLoopPerformBlock(self.currentRunLoop, runLoopSimpleModeRaw) {

--- a/Tests/SolanaTests/Vendor/TransactionParser.swift
+++ b/Tests/SolanaTests/Vendor/TransactionParser.swift
@@ -21,8 +21,7 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("SwapTransaction")
         
         let myAccountSymbol = "SOL"
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: myAccountSymbol)
-            .toBlocking().first()?.value as! SwapTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: myAccountSymbol)?.get().value as! SwapTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "SRM")
         XCTAssertEqual(transaction.source?.pubkey, "BjUEdE292SLEq9mMeKtY3GXL6wirn7DqJPhrukCqAUua")
@@ -35,8 +34,7 @@ class TransactionParserTests: XCTestCase {
     func testDecodingCreateAccountTransaction() {
         let transactionInfo = transactionInfoFromJSONFileName("CreateAccountTransaction")
         
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! CreateAccountTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: nil)?.get().value as! CreateAccountTransaction
         
         XCTAssertEqual(transaction.fee, 0.00203928)
         XCTAssertEqual(transaction.newWallet?.token.symbol, "ETH")
@@ -46,8 +44,7 @@ class TransactionParserTests: XCTestCase {
     func testDecodingCloseAccountTransaction()  {
         let transactionInfo = transactionInfoFromJSONFileName("CloseAccountTransaction")
         
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! CloseAccountTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: nil, myAccountSymbol: nil)?.get().value as! CloseAccountTransaction
         
         XCTAssertEqual(transaction.reimbursedAmount, 0.00203928)
         XCTAssertEqual(transaction.closedWallet?.token.symbol, "ETH")
@@ -57,8 +54,7 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("SendSOLTransaction")
         
         let myAccount = "6QuXb6mB6WmRASP2y8AavXh6aabBXEH5ZzrSH5xRrgSm"
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "SOL")
         XCTAssertEqual(transaction.source?.pubkey, myAccount)
@@ -70,8 +66,7 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("SendSOLTransactionPaidByP2PORG")
         
         let myAccount = "6QuXb6mB6WmRASP2y8AavXh6aabBXEH5ZzrSH5xRrgSm"
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "SOL")
         XCTAssertEqual(transaction.source?.pubkey, myAccount)
@@ -82,8 +77,7 @@ class TransactionParserTests: XCTestCase {
     func testDecodingSendSPLToSOLTransaction() {
         let transactionInfo = transactionInfoFromJSONFileName("SendSPLToSOLTransaction")
         let myAccount = "22hXC9c4SGccwCkjtJwZ2VGRfhDYh9KSRCviD8bs4Xbg"
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "wUSDT")
         XCTAssertEqual(transaction.source?.pubkey, myAccount)
@@ -94,8 +88,7 @@ class TransactionParserTests: XCTestCase {
     func testDecodingSendSPLToSPLTransaction() {
         let transactionInfo = transactionInfoFromJSONFileName("SendSPLToSPLTransaction")
         let myAccount = "BjUEdE292SLEq9mMeKtY3GXL6wirn7DqJPhrukCqAUua"
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "SRM")
         XCTAssertEqual(transaction.source?.pubkey, myAccount)
@@ -108,8 +101,7 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("SendTokenToNewAssociatedTokenAddress")
         let myAccount = "H1yu3R247X5jQN9bbDU8KB7RY4JSeEaCv45p5CMziefd"
         
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: "MAPS")
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: "MAPS")?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction.source?.token.symbol, "MAPS")
         XCTAssertEqual(transaction.source?.pubkey, myAccount)
@@ -117,8 +109,7 @@ class TransactionParserTests: XCTestCase {
         
         // transfer checked type
         let transactionInfo2 = transactionInfoFromJSONFileName("SendTokenToNewAssociatedTokenAddressTransferChecked")
-        let transaction2 = try! parser.parse(transactionInfo: transactionInfo2, myAccount: myAccount, myAccountSymbol: "MAPS")
-            .toBlocking().first()?.value as! TransferTransaction
+        let transaction2 = try! parser.parse(transactionInfo: transactionInfo2, myAccount: myAccount, myAccountSymbol: "MAPS")?.get().value as! TransferTransaction
         
         XCTAssertEqual(transaction2.source?.token.symbol, "MAPS")
         XCTAssertEqual(transaction2.source?.pubkey, myAccount)
@@ -130,10 +121,9 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("ProvideLiquidityToPoolTransaction")
         let myAccount = "H1yu3R247X5jQN9bbDU8KB7RY4JSeEaCv45p5CMziefd"
         
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()!
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get()
         
-        XCTAssertNil(transaction.value)
+        XCTAssertNil(transaction?.value)
     }
     
     func testDecodingBurnLiquidityInPoolTransaction() {
@@ -141,10 +131,9 @@ class TransactionParserTests: XCTestCase {
         let transactionInfo = transactionInfoFromJSONFileName("BurnLiquidityInPoolTransaction")
         let myAccount = "H1yu3R247X5jQN9bbDU8KB7RY4JSeEaCv45p5CMziefd"
         
-        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)
-            .toBlocking().first()!
+        let transaction = try! parser.parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: nil)?.get()
         
-        XCTAssertNil(transaction.value)
+        XCTAssertNil(transaction?.value)
     }
     
     private func transactionInfoFromJSONFileName(_ name: String) -> TransactionInfo {

--- a/Tests/SolanaTests/Vendor/TranscationParser+SimpleLock.swift
+++ b/Tests/SolanaTests/Vendor/TranscationParser+SimpleLock.swift
@@ -1,0 +1,28 @@
+//
+//  TranscationParser+SimpleLock.swift
+//
+//  Created by Dezork
+//
+
+import Foundation
+import Solana
+
+extension TransactionParser {
+
+    func parse(
+        transactionInfo: TransactionInfo,
+        myAccount: String?,
+        myAccountSymbol: String?
+    ) -> Result<AnyTransaction, Error>? {
+        var transaction: Result<AnyTransaction, Error>?
+        let lock = RunLoopSimpleLock()
+        lock.dispatch {
+            parse(transactionInfo: transactionInfo, myAccount: myAccount, myAccountSymbol: myAccountSymbol) {
+                transaction = $0
+                lock.stop()
+            }
+        }
+        lock.run()
+        return transaction
+    }
+}


### PR DESCRIPTION
All RxSwift Dependencies were removed from tests.

Next step:
Move RxSolana to separate package and remove RxSwift dependency from Solana package.

@ajamaica when I separate  RxSolana package I can send you an archive to your email or I can make a repo in my repositories and give you a link so you can download and publish it in yours and then I will remove it from mines. Let me know what you would prefer.