### PR TITLE
Support bip32 deprecated key

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "secp256k1",
+        "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
+          "version": "0.1.4"
+        }
+      },
+      {
         "package": "Starscream",
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,14 +19,15 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "TweetNacl", url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git", from: "1.0.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2.0"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0")
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
+        .package(name: "secp256k1", url: "https://github.com/Boilertalk/secp256k1.swift.git", from: "0.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Solana",
-            dependencies: ["TweetNacl", "Starscream"],
+            dependencies: ["TweetNacl", "Starscream", "secp256k1"],
             resources: [ .process("Resources")
             ]
         ),
@@ -38,7 +39,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SolanaTests",
-            dependencies: ["RxSolana", "TweetNacl", "RxSwift", "Starscream", .product(name: "RxBlocking", package: "RxSwift")],
+            dependencies: ["RxSolana", "TweetNacl", "RxSwift", "Starscream", "secp256k1", .product(name: "RxBlocking", package: "RxSwift")],
             resources: [ .process("Resources")
             ]
         )

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please check my wallet [Summer](https://github.com/ajamaica/Summer).
 - [x] Key pair generation
 - [x] RPC configuration.
 - [x] SPM integration
-- [x] Few libraries requirement (TweetNACL, Starscream). Rxswift is optional.
+- [x] Few libraries requirement (TweetNACL, Starscream, secp256k1). Rxswift is optional.
 - [x] Fully tested (53%)
 - [x] Sockets
 - [ ] Type-safe Transaction templates

--- a/Sources/Solana/Models/DerivablePath.swift
+++ b/Sources/Solana/Models/DerivablePath.swift
@@ -3,10 +3,13 @@ import Foundation
 public struct DerivablePath: Hashable {
     // MARK: - Nested type
     public enum DerivableType: String, CaseIterable {
+        case bip32Deprecated
         case bip44Change
         case bip44
         var prefix: String {
             switch self {
+            case .bip32Deprecated:
+                return "m/501'"
             case .bip44, .bip44Change:
                 return "m/44'/501'"
             }
@@ -35,6 +38,8 @@ public struct DerivablePath: Hashable {
     public var rawValue: String {
         var value = type.prefix
         switch type {
+        case .bip32Deprecated:
+            value += "/\(walletIndex)'/0/\(accountIndex ?? 0)"
         case .bip44:
             value += "/\(walletIndex)'"
         case .bip44Change:

--- a/Sources/Solana/Vendor/AskCoin-HD/ASKHDUtils.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/ASKHDUtils.swift
@@ -1,0 +1,106 @@
+//
+//  ASKHDUtils.swift
+//  AskCoin-HD
+//
+//  Created by 仇弘扬 on 2017/8/16.
+//  Copyright © 2017年 askcoin. All rights reserved.
+//
+
+import Foundation
+
+protocol HexToData {
+	func ask_hexToData() -> Data
+}
+
+extension UInt32: HexToData {
+	func ask_hexToData() -> Data {
+		var v = self.byteSwapped
+		let data = Data(bytes: &v, count: MemoryLayout<UInt32>.size)
+		return data
+	}
+}
+
+extension UInt8: HexToData {
+	func ask_hexToData() -> Data {
+		var v = self
+		let data = Data(bytes: &v, count: MemoryLayout<UInt8>.size)
+		return data
+	}
+}
+
+extension String {
+	
+	/// Create `Data` from hexadecimal string representation
+	///
+	/// This takes a hexadecimal representation and creates a `Data` object. Note, if the string has any spaces or non-hex characters (e.g. starts with '<' and with a '>'), those are ignored and only hex characters are processed.
+	///
+	/// - returns: Data represented by this hexadecimal string.
+	
+	func ask_hexadecimal() -> Data? {
+		var data = Data(capacity: self.count / 2)
+		
+		let regex = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .caseInsensitive)
+		regex.enumerateMatches(in: self, range: NSMakeRange(0, utf16.count)) { match, flags, stop in
+			let byteString = (self as NSString).substring(with: match!.range)
+			var num = UInt8(byteString, radix: 16)!
+			data.append(&num, count: 1)
+		}
+		
+		guard data.count > 0 else { return nil }
+		
+		return data
+	}
+	
+}
+
+extension Data {
+	
+	/// Create hexadecimal string representation of `Data` object.
+	///
+	/// - returns: `String` representation of this `Data` object.
+	
+	func ask_hexadecimal() -> String {
+		return map { String(format: "%02x", $0) }
+			.joined(separator: "")
+	}
+}
+
+extension Data {
+	func ask_BTCHash256() -> Data {
+		return sha256(data: self)
+	}
+	func ask_BTCHash160() -> Data {
+        return RIPEMD.digest(sha256(data: self))
+	}
+	func ask_BTCHash160String() -> String {
+		return ask_BTCHash160().toHexString()
+	}
+	func ck_reversedData() -> Data {
+		return Data(reversed())
+	}
+	func ask_base58Check() -> String {
+		return Base58.encode([UInt8](self))
+	}
+	static func dataFromHexString(hexString: String) -> Data {
+		let data = Data()
+		
+		return data
+	}
+}
+
+// Copy from CryptoSwift/UInt32+Extension.swift
+extension UInt32 {
+	
+	init<T: Collection>(bytes: T) where T.Iterator.Element == UInt8, T.Index == Int {
+		self = UInt32(bytes: bytes, fromIndex: bytes.startIndex)
+	}
+	
+	init<T: Collection>(bytes: T, fromIndex index: T.Index) where T.Iterator.Element == UInt8, T.Index == Int {
+		let val0 = UInt32(bytes[index.advanced(by: 0)]) << 24
+		let val1 = UInt32(bytes[index.advanced(by: 1)]) << 16
+		let val2 = UInt32(bytes[index.advanced(by: 2)]) << 8
+		let val3 = UInt32(bytes[index.advanced(by: 3)])
+		
+		self = val0 | val1 | val2 | val3
+	}
+}

--- a/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/Keychain.swift
@@ -1,0 +1,261 @@
+//
+//  ASKKeychain.swift
+//  AskCoin-HD
+//
+//  Created by 仇弘扬 on 2017/8/14.
+//  Copyright © 2017年 askcoin. All rights reserved.
+//
+import Foundation
+
+let BTCKeychainMainnetPrivateVersion: UInt32 = 0x0488ADE4
+let BTCKeychainMainnetPublicVersion: UInt32 = 0x0488B21E
+
+let BTCKeychainTestnetPrivateVersion: UInt32 = 0x04358394
+let BTCKeychainTestnetPublicVersion: UInt32 = 0x043587CF
+
+let BTCMasterKeychainPath = "m"
+let BTCKeychainHardenedSymbol = "'"
+let BTCKeychainPathSeparator = "/"
+
+public class Keychain: NSObject {
+	
+	enum KeyDerivationError: Error {
+		case indexInvalid
+		case pathInvalid
+		case privateKeyNil
+		case publicKeyNil
+		case chainCodeNil
+		case notMasterKey
+	}
+	
+	public var privateKey: Data?
+	//	private var publicKey: Data?
+	private var chainCode: Data?
+	
+	fileprivate var isMasterKey = false
+    var isTestnet = false
+	
+	var depth: UInt8 = 0
+	var hardened = false
+	var index: UInt32 = 0
+	
+	override init() {
+		
+	}
+	
+    public convenience init(seedString: String, network: String) throws {
+        let seed = Mnemonic(phrase: seedString.components(separatedBy: " "))!.seed
+        let hmac = hmacSha512(message: Data(seed), key: "Bitcoin seed".data(using: .utf8)!)!.bytes
+        self.init(hmac: hmac)
+        isMasterKey = true
+        isTestnet = network == "devnet" || network == "testnet"
+	}
+	
+	public init(hmac: Array<UInt8>) {
+		privateKey = Data(hmac[0..<32])
+		chainCode = Data(hmac[32..<64])
+	}
+	
+	public lazy var identifier: Data? = {
+		if let pubKey = self.publicKey {
+			return pubKey.ask_BTCHash160()
+		}
+		return nil
+	}()
+	
+	public var parentFingerprint: UInt32 = 0
+	
+	public lazy var fingerprint: UInt32 = {
+		if let id = self.identifier {
+			return UInt32(bytes: id.bytes[0..<4])
+		}
+		return 0
+	}()
+	
+	private lazy var publicKey: Data? = {
+		guard let prvKey = self.privateKey else {
+			return nil
+		}
+		return CKSecp256k1.generatePublicKey(withPrivateKey: prvKey, compression: true)
+	}()
+	
+	// MARK: - Extended private key
+	public lazy var extendedPrivateKey: String = {
+		self.extendedPrivateKeyData.ask_base58Check()
+	}()
+	
+	public lazy var extendedPrivateKeyData: Data = {
+		guard self.privateKey != nil else {
+			return Data()
+		}
+		
+		var toReturn = Data()
+		
+		let version = !isTestnet ? BTCKeychainMainnetPrivateVersion : BTCKeychainTestnetPrivateVersion
+		toReturn += self.extendedKeyPrefix(with: version)
+		
+		toReturn += UInt8(0).ask_hexToData()
+		
+		if let prikey = self.privateKey {
+			toReturn += prikey
+		}
+		
+		return toReturn
+	}()
+	
+	// MARK: - Extended public key
+	public lazy var extendedPublicKey: String = {
+		self.extendedPublicKeyData.ask_base58Check()
+	}()
+	
+	public lazy var extendedPublicKeyData: Data = {
+		guard self.publicKey != nil else {
+			return Data()
+		}
+		
+		var toReturn = Data()
+		
+		let version = !isTestnet ? BTCKeychainMainnetPublicVersion : BTCKeychainTestnetPublicVersion
+		toReturn += self.extendedKeyPrefix(with: version)
+		
+		if let pubkey = self.publicKey {
+			toReturn += pubkey
+		}
+		
+		return toReturn
+	}()
+	
+	func extendedKeyPrefix(with version: UInt32) -> Data {
+		var toReturn = Data()
+		
+		let versionData = version.ask_hexToData()
+		toReturn += versionData
+		
+		let depthData = depth.ask_hexToData()
+		toReturn += depthData
+		
+		let parentFPData = parentFingerprint.ask_hexToData()
+		toReturn += parentFPData
+		
+		let childIndex = hardened ? (0x80000000 | index) : index
+		let childIndexData = childIndex.ask_hexToData()
+		toReturn += childIndexData
+		
+		if let cCode = chainCode {
+			toReturn += cCode
+		}
+		else
+		{
+			print(KeyDerivationError.chainCodeNil)
+		}
+		
+		return toReturn
+	}
+	
+	public func derivedKeychain(at path: String) throws -> Keychain {
+		
+		if path == BTCMasterKeychainPath || path == BTCKeychainPathSeparator || path == "" {
+			return self
+		}
+		
+		var paths = path.components(separatedBy: BTCKeychainPathSeparator)
+		if path.hasPrefix(BTCMasterKeychainPath) {
+			paths.removeFirst()
+		}
+		
+		var kc = self
+		
+		for indexString in paths {
+			var isHardened = false
+			var temp = indexString
+			if indexString.hasSuffix(BTCKeychainHardenedSymbol) {
+				isHardened = true
+				temp = temp.substring(to: temp.index(temp.endIndex, offsetBy: -1))
+			}
+			if let index = UInt32(temp) {
+				kc = try kc.derivedKeychain(at: index, hardened: isHardened)
+				continue
+			}
+			throw KeyDerivationError.pathInvalid
+		}
+		
+		return kc
+	}
+	
+	public func derivedKeychain(at index: UInt32, hardened: Bool = true) throws -> Keychain {
+		
+		let edge: UInt32 = 0x80000000
+		
+		guard (edge & UInt32(index)) == 0 else {
+			throw KeyDerivationError.indexInvalid
+		}
+		
+		guard let prvKey = privateKey else {
+			throw KeyDerivationError.privateKeyNil
+		}
+		
+		guard let pubKey = publicKey else {
+			throw KeyDerivationError.publicKeyNil
+		}
+		
+		guard let chCode = chainCode else {
+			throw KeyDerivationError.chainCodeNil
+		}
+		
+		var data = Data()
+		
+		if hardened {
+			let padding: UInt8 = 0
+			data += padding.ask_hexToData()
+			data += prvKey
+		}
+		else
+		{
+			data += pubKey
+		}
+		
+		let indexBE = hardened ? (edge + index) : index
+		data += indexBE.ask_hexToData()
+		
+        
+        let digestArray = hmacSha512(message: data, key: chCode)!.bytes
+		
+		let factor = BInt(data: Data(digestArray[0..<32]))
+		let curveOrder = BInt(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")
+		
+        let derivedKeychain = Keychain(hmac: digestArray)
+		
+		let pkNum = BInt(data: Data(prvKey))
+		
+		let pkData = ((pkNum + factor) % curveOrder).data
+		
+		derivedKeychain.privateKey = pkData
+		derivedKeychain.depth = depth + 1
+		derivedKeychain.parentFingerprint = fingerprint
+		derivedKeychain.index = index
+		derivedKeychain.hardened = hardened
+		
+		return derivedKeychain
+	}
+	
+}
+
+// MARK: - BIP44
+extension Keychain {
+	
+	public func checkMasterKey() throws {
+		guard isMasterKey else {
+			throw KeyDerivationError.notMasterKey
+		}
+	}
+	
+	public func bitcoinMainnetKeychain() throws -> Keychain {
+		try checkMasterKey()
+		return try derivedKeychain(at: "44'/0'")
+	}
+	public func bitcoinTestnetKeychain() throws -> Keychain {
+		try checkMasterKey()
+		return try derivedKeychain(at: "44'/1'")
+	}
+}
+

--- a/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/RIPEMD+Block.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/RIPEMD+Block.swift
@@ -1,0 +1,199 @@
+//
+//  RIPEMD+Block.swift
+//  RIPEMD
+//
+//  Created by Sjors Provoost on 08-07-14.
+//
+
+extension RIPEMD {
+    // FIXME: Make struct and all functions framework-only as soon as tests support that
+    public struct Block {
+        public init() {}
+        
+        var message: [UInt32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+        
+        // Initial values
+        var h₀: UInt32 = 0x67452301
+        var h₁: UInt32 = 0xEFCDAB89
+        var h₂: UInt32 = 0x98BADCFE
+        var h₃: UInt32 = 0x10325476
+        var h₄: UInt32 = 0xC3D2E1F0
+        
+        public var hash: [UInt32] {
+            return [h₀, h₁, h₂, h₃, h₄]
+        }
+        
+        // FIXME: Make private as soon as tests support that
+        public mutating func compress (_ message: [UInt32]) -> () {
+            assert(message.count == 16, "Wrong message size")
+            
+            var Aᴸ = h₀
+            var Bᴸ = h₁
+            var Cᴸ = h₂
+            var Dᴸ = h₃
+            var Eᴸ = h₄
+            
+            var Aᴿ = h₀
+            var Bᴿ = h₁
+            var Cᴿ = h₂
+            var Dᴿ = h₃
+            var Eᴿ = h₄
+            
+            for j in 0...79 {
+                // Left side
+                let wordᴸ = message[r.left[j]]
+                let functionᴸ = f(j)
+                
+                let Tᴸ: UInt32 = ((Aᴸ &+ functionᴸ(Bᴸ,Cᴸ,Dᴸ) &+ wordᴸ &+ K.left[j]) ~<< s.left[j]) &+ Eᴸ
+                
+                Aᴸ = Eᴸ
+                Eᴸ = Dᴸ
+                Dᴸ = Cᴸ ~<< 10
+                Cᴸ = Bᴸ
+                Bᴸ = Tᴸ
+                
+                // Right side
+                let wordᴿ = message[r.right[j]]
+                let functionᴿ = f(79 - j)
+                
+                let Tᴿ: UInt32 = ((Aᴿ &+ functionᴿ(Bᴿ,Cᴿ,Dᴿ) &+ wordᴿ &+ K.right[j]) ~<< s.right[j]) &+ Eᴿ
+                
+                Aᴿ = Eᴿ
+                Eᴿ = Dᴿ
+                Dᴿ = Cᴿ ~<< 10
+                Cᴿ = Bᴿ
+                Bᴿ = Tᴿ
+            }
+            
+            let T = h₁ &+ Cᴸ &+ Dᴿ
+            h₁ = h₂ &+ Dᴸ &+ Eᴿ
+            h₂ = h₃ &+ Eᴸ &+ Aᴿ
+            h₃ = h₄ &+ Aᴸ &+ Bᴿ
+            h₄ = h₀ &+ Bᴸ &+ Cᴿ
+            h₀ = T
+        }
+        
+        public func f (_ j: Int) -> ((UInt32, UInt32, UInt32) -> UInt32) {
+            switch j {
+            case _ where j < 0:
+                assert(false, "Invalid j")
+                return {(_, _, _) in 0 }
+            case _ where j <= 15:
+                return {(x, y, z) in  x ^ y ^ z }
+            case _ where j <= 31:
+                return {(x, y, z) in  (x & y) | (~x & z) }
+            case _ where j <= 47:
+                return {(x, y, z) in  (x | ~y) ^ z }
+            case _ where j <= 63:
+                return {(x, y, z) in  (x & z) | (y & ~z) }
+            case _ where j <= 79:
+                return {(x, y, z) in  x ^ (y | ~z) }
+            default:
+                assert(false, "Invalid j")
+                return {(_, _, _) in 0 }
+            }
+        }
+        
+        public enum K {
+            case left, right
+            
+            public subscript(j: Int) -> UInt32 {
+                switch j {
+                case _ where j < 0:
+                    assert(false, "Invalid j")
+                    return 0
+                case _ where j <= 15:
+                    return self == .left ? 0x00000000 : 0x50A28BE6
+                case _ where j <= 31:
+                    return self == .left ? 0x5A827999 : 0x5C4DD124
+                case _ where j <= 47:
+                    return self == .left ? 0x6ED9EBA1 : 0x6D703EF3
+                case _ where j <= 63:
+                    return self == .left ? 0x8F1BBCDC : 0x7A6D76E9
+                case _ where j <= 79:
+                    return self == .left ? 0xA953FD4E : 0x00000000
+                default:
+                    assert(false, "Invalid j")
+                    return 0
+                    }
+            }
+        }
+        
+        public enum r {
+            case left, right
+            
+            public subscript (j: Int) -> Int {
+                switch j {
+                case _ where j < 0:
+                    assert(false, "Invalid j")
+                    return 0
+                case let index where j <= 15:
+                    if self == .left {
+                        return index
+                    } else {
+                        return [5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12][index]
+                    }
+                case let index where j <= 31:
+                    if self == .left {
+                        return [ 7, 4,13, 1,10, 6,15, 3,12, 0, 9, 5, 2,14,11, 8][index - 16]
+                    } else {
+                        return [ 6,11, 3, 7, 0,13, 5,10,14,15, 8,12, 4, 9, 1, 2][index - 16]
+                    }
+                case let index where j <= 47:
+                    if self == .left {
+                        return [3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12][index - 32]
+                    } else {
+                        return [15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13][index - 32]
+                    }
+                case let index where j <= 63:
+                    if self == .left {
+                        return [1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2][index - 48]
+                    } else {
+                        return [8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14][index - 48]
+                    }
+                case let index where j <= 79:
+                    if self == .left {
+                        return [ 4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13][index - 64]
+                    } else {
+                        return [12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11][index - 64]
+                    }
+
+                default:
+                    assert(false, "Invalid j")
+                    return 0
+                }
+            }
+
+            
+        }
+        
+        public enum s {
+            case left, right
+            
+            public subscript(j: Int) -> Int {
+                switch j {
+                case _ where j < 0:
+                    assert(false, "Invalid j")
+                    return 0
+                case _ where j <= 15:
+                    return (self == .left ? [11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8] : [8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6])[j]
+                case _ where j <= 31:
+                    return (self == .left ? [7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12] : [9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11])[j - 16]
+                case _ where j <= 47:
+                    return (self == .left ? [11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5] : [9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5])[j - 32]
+                case _ where j <= 63:
+                    return (self == .left ? [11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12] : [15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8])[j - 48]
+                case _ where j <= 79:
+                    return (self == .left ? [9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6] : [8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11])[j - 64]
+                default:
+                    assert(false, "Invalid j")
+                    return 0
+                    }
+            }
+
+        }
+        
+        
+        
+    }
+}

--- a/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/RIPEMD.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/RIPEMD.swift
@@ -1,0 +1,119 @@
+//
+//  RIPEMD.swift
+//  RIPEMD
+//
+//  Created by Sjors Provoost on 08-07-14.
+//
+
+import Foundation
+
+public struct RIPEMD {
+    public static func digest (_ input : Data, bitlength:Int = 160) -> Data {
+        assert(bitlength == 160, "Only RIPEMD-160 is implemented")
+        
+        let paddedData = pad(input)
+        
+        var block = RIPEMD.Block()
+        
+        for i in 0 ..< paddedData.count / 64 {
+            let part = getWordsInSection(paddedData, i)
+            block.compress(part)
+        }
+
+        return encodeWords(block.hash)
+    }
+    
+    // Pads the input to a multiple 64 bytes. First it adds 0x80 followed by zeros.
+    // It then needs 8 bytes at the end where it writes the length (in bits, little endian).
+    // If this doesn't fit it will add another block of 64 bytes.
+    
+    // FIXME: Make private once tests support it
+    public static func pad(_ data: Data) -> Data {
+        let paddedData = (data as NSData).mutableCopy() as! NSMutableData
+        
+        // Put 0x80 after the last character:
+        let stop: [UInt8] = [UInt8(0x80)] // 2^8
+        paddedData.append(stop, length: 1)
+        
+        // Pad with zeros until there are 64 * k - 8 bytes.
+        var numberOfZerosToPad: Int;
+        if paddedData.length % 64 == 56 {
+            // No padding needed
+            numberOfZerosToPad = 0
+        } else if paddedData.length % 64 < 56 {
+            numberOfZerosToPad = 56 - (paddedData.length % 64)
+        } else {
+            // Add an extra round
+            numberOfZerosToPad = 56 + (64 - paddedData.length % 64)
+        }
+        
+        let zeroBytes = [UInt8](repeating: 0, count: numberOfZerosToPad)
+        paddedData.append(zeroBytes, length: numberOfZerosToPad)
+        
+        // Append length of message:
+        let length: UInt32 = UInt32(data.count) * 8
+        let lengthBytes: [UInt32] = [length, UInt32(0x00_00_00_00)]
+        paddedData.append(lengthBytes, length: 8)
+        
+        return paddedData as Data
+    }
+    
+    // Takes an NSData object of length k * 64 bytes and returns an array of UInt32 
+    // representing 1 word (4 bytes) each. Each word is in little endian,
+    // so "abcdefgh" is now "dcbahgfe".
+    // FIXME: Make private once tests support it
+    public static func getWordsInSection(_ data: Data, _ section: Int) -> [UInt32] {
+        let offset = section * 64
+        
+        assert(data.count >= Int(offset + 64), "Data too short")
+        
+         var words: [UInt32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+         (data as NSData).getBytes(&words, range: NSMakeRange(offset, 64))
+
+        
+        return words
+    }
+    
+    // FIXME: Make private once tests support it
+    public static func encodeWords(_ input: [UInt32]) -> Data {
+        let data = NSMutableData(bytes: input, length: 20)
+        return data as Data
+    }
+    
+    // Returns a string representation of a hexadecimal number
+    public static func digest (_ input : Data, bitlength:Int = 160) -> String {
+        return digest(input, bitlength: bitlength).toHexString()
+    }
+    
+    // Takes a string representation of a hexadecimal number
+    public static func hexStringDigest (_ input : String, bitlength:Int = 160) -> Data {
+        let data = Data.dataFromHexString(hexString: input)
+        return digest(data, bitlength: bitlength)
+    }
+    
+    // Takes a string representation of a hexadecimal number and returns a
+    // string represenation of the resulting 160 bit hash.
+    public static func hexStringDigest (_ input : String, bitlength:Int = 160) -> String {
+        let digest: Data = hexStringDigest(input, bitlength: bitlength)
+        return digest.toHexString()
+    }
+    
+    // Takes an ASCII string
+    public static func asciiDigest (_ input : String, bitlength:Int = 160) -> Data {
+        // Order of bytes is preserved; if the last character is dot, the last 
+        // byte is a dot.
+        if let data: Data = input.data(using: String.Encoding.ascii) {
+            return digest(data, bitlength: bitlength)
+        } else {
+            assert(false, "Invalid input")
+            return Data()
+        }
+    }
+    
+//     Takes an ASCII string and returns a hex string represenation of the
+//     resulting 160 bit hash.
+    public static func asciiDigest (_ input : String, bitlength:Int = 160) -> String {
+        return asciiDigest(input, bitlength: bitlength).toHexString()
+    }
+    
+}

--- a/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/UInt32+CircularShift.swift
+++ b/Sources/Solana/Vendor/AskCoin-HD/RIPEMD/UInt32+CircularShift.swift
@@ -1,0 +1,15 @@
+//
+//  RIPEMD+CircularShift.swift
+//  RIPEMD
+//
+//  Created by Sjors Provoost on 08-07-14.
+//
+
+// Circular left shift: http://en.wikipedia.org/wiki/Circular_shift
+// Precendence should be the same as <<
+infix operator  ~<< : BitwiseShiftPrecedence
+
+//FIXME: Make framework-only once tests support it
+public func ~<< (lhs: UInt32, rhs: Int) -> UInt32 {
+    return (lhs << UInt32(rhs)) | (lhs >> UInt32(32 - rhs));
+}

--- a/Sources/Solana/Vendor/CKSecp256k1.swift
+++ b/Sources/Solana/Vendor/CKSecp256k1.swift
@@ -1,0 +1,149 @@
+import Foundation
+import secp256k1
+
+struct CKSecp256k1 {
+    /*
+     + (NSData *)generatePublicKeyWithPrivateKey:(NSData *)privateKeyData compression:(BOOL)isCompression
+     {
+         secp256k1_context *context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+         
+         const unsigned char *prvKey = (const unsigned char *)privateKeyData.bytes;
+         secp256k1_pubkey pKey;
+         
+         int result = secp256k1_ec_pubkey_create(context, &pKey, prvKey);
+         if (result != 1) {
+             return nil;
+         }
+         
+         int size = isCompression ? 33 : 65;
+         unsigned char *pubkey = malloc(size);
+         
+         size_t s = size;
+         
+         result = secp256k1_ec_pubkey_serialize(context, pubkey, &s, &pKey, isCompression ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+         if (result != 1) {
+             return nil;
+         }
+         
+         secp256k1_context_destroy(context);
+         
+         NSMutableData *data = [NSMutableData dataWithBytes:pubkey length:size];
+         free(pubkey);
+         return data;
+     }
+     */
+    static func generatePublicKey(withPrivateKey privateKeyData: Data, compression isCompression: Bool) -> Data? {
+        let context = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN))!
+        let prvKey = privateKeyData.bytes
+        var pKey = secp256k1_pubkey()
+
+        var result = secp256k1_ec_pubkey_create(context, &pKey, prvKey)
+        if (result != 1) {
+            return nil
+        }
+
+        let size = isCompression ? 33 : 65
+        let pubkey = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+        var s = size
+
+        result = secp256k1_ec_pubkey_serialize(context, pubkey, &s, &pKey, UInt32(isCompression ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
+        if (result != 1) {
+            return nil
+        }
+
+        secp256k1_context_destroy(context);
+
+        let data = NSMutableData(bytes: pubkey, length:size).copy()
+        return data as? Data
+    }
+    /*
+     + (NSData *)compactSignData:(NSData *)msgData withPrivateKey:(NSData *)privateKeyData
+     {
+         secp256k1_context *context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+         
+         const unsigned char *prvKey = (const unsigned char *)privateKeyData.bytes;
+         const unsigned char *msg = (const unsigned char *)msgData.bytes;
+         
+         unsigned char *siga = malloc(64);
+         secp256k1_ecdsa_signature sig;
+         int result = secp256k1_ecdsa_sign(context, &sig, msg, prvKey, NULL, NULL);
+         
+         result = secp256k1_ecdsa_signature_serialize_compact(context, siga, &sig);
+         
+         if (result != 1) {
+             return nil;
+         }
+         
+         secp256k1_context_destroy(context);
+         
+         NSMutableData *data = [NSMutableData dataWithBytes:siga length:64];
+         free(siga);
+         return data;
+     }
+     */
+    static func compactSignData(msgData: Data, withPrivateKey privateKeyData: Data) -> Data? {
+        let context = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN))!
+        let prvKey = privateKeyData.bytes
+        let msg = msgData.bytes
+        let siga = UnsafeMutablePointer<UInt8>.allocate(capacity: 64)
+        var sig = secp256k1_ecdsa_signature()
+
+        var result = secp256k1_ecdsa_sign(context, &sig, msg, prvKey, nil, nil)
+        result = secp256k1_ecdsa_signature_serialize_compact(context, siga, &sig);
+
+        if (result != 1) {
+            return nil;
+        }
+
+        secp256k1_context_destroy(context);
+
+        let data = NSMutableData(bytes: siga, length:64).copy()
+        return data as? Data
+    }
+
+    /*
+     + (NSInteger)verifySignedData:(NSData *)sigData withMessageData:(NSData *)msgData usePublickKey:(NSData *)pubKeyData
+    {
+        secp256k1_context *context = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
+        
+        const unsigned char *sig = (const unsigned char *)sigData.bytes;
+        const unsigned char *msg = (const unsigned char *)msgData.bytes;
+        
+        const unsigned char *pubKey = (const unsigned char *)pubKeyData.bytes;
+        
+        secp256k1_pubkey pKey;
+        int pubResult = secp256k1_ec_pubkey_parse(context, &pKey, pubKey, pubKeyData.length);
+        if (pubResult != 1) return -3;
+        
+        secp256k1_ecdsa_signature sig_ecdsa;
+        int sigResult = secp256k1_ecdsa_signature_parse_compact(context, &sig_ecdsa, sig);
+        if (sigResult != 1) return -4;
+        
+        int result = secp256k1_ecdsa_verify(context, &sig_ecdsa, msg, &pKey);
+        
+        secp256k1_context_destroy(context);
+        return result;
+    }*/
+    static func verifySignedData(sigData: Data, withMessageData msgData: Data, usePublickKey pubKeyData: Data) -> Int32 {
+
+        let context = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN))!
+        let sig = sigData.bytes
+        let msg = msgData.bytes
+
+        let pubKey = pubKeyData.bytes
+        var pKey = secp256k1_pubkey()
+
+        let pubResult = secp256k1_ec_pubkey_parse(context, &pKey, pubKey, pubKeyData.count);
+        if (pubResult != 1){ return -3 }
+
+        var sig_ecdsa = secp256k1_ecdsa_signature()
+        let sigResult = secp256k1_ecdsa_signature_parse_compact(context, &sig_ecdsa, sig);
+        if (sigResult != 1){ return -4 }
+
+        let result = secp256k1_ecdsa_verify(context, &sig_ecdsa, msg, &pKey);
+
+        secp256k1_context_destroy(context);
+        return result
+    }
+
+}

--- a/Tests/SolanaTests/Models/PublicKey.swift
+++ b/Tests/SolanaTests/Models/PublicKey.swift
@@ -127,4 +127,15 @@ class PublicKeyTests: XCTestCase {
         let account24 = Account(phrase: phrase24, network: .mainnetBeta)!
         XCTAssertEqual(account24.publicKey.base58EncodedString, "9avcmC97zLPwHKXiDz6GpXyjvPn9VcN3ggqM5gsRnjvv")
     }
+    
+    func testRestoreAccountFromSeedPhraseBip32Deprecated() {
+        let phrase24 = "hint begin crowd dolphin drive render finger above sponsor prize runway invest dizzy pony bitter trial ignore crop please industry hockey wire use side"
+            .components(separatedBy: " ")
+        let account24 = Account(phrase: phrase24, network: .mainnetBeta, derivablePath: DerivablePath(
+            type: .bip32Deprecated,
+            walletIndex: 0,
+            accountIndex: 0
+        ))!
+        XCTAssertEqual(account24.publicKey.base58EncodedString, "8knQfbiYmUfwsfcSihzX9FMU64GCc5XWcfcZtyNCoHSB")
+    }
 }


### PR DESCRIPTION
This PR restore some lost logic but with less dependencys. Secp256k1 is not available on ios Crypto libs. I used the framework (writen on C) available and wrote a wrapper on swift on CKSecp256k1. I will try to remove this dependency on the future.