### PR TITLE
Action Templates

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "secp256k1",
+        "package": "secp256k1.swift",
         "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
         "state": {
           "branch": null,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "package": "TweetNacl",
+        "package": "tweetnacl-swiftwrap",
         "repositoryURL": "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git",
         "state": {
           "branch": null,

--- a/Sources/Solana/Actions/ActionTemplate.swift
+++ b/Sources/Solana/Actions/ActionTemplate.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public protocol ActionTemplate {
+    associatedtype Success
+
+    func perform(withConfigurationFrom actionClass: Action,
+                 completion: @escaping (Result<Success, Error>) -> Void)
+}
+
+public extension Action {
+    func perform<ActionType: ActionTemplate>(_ modeledAction: ActionType,
+                                             completion: @escaping (Result<ActionType.Success, Error>) -> Void) {
+        modeledAction.perform(withConfigurationFrom: self, completion: completion)
+    }
+}
+
+
+public enum ActionTemplates {}

--- a/Sources/Solana/Actions/closeTokenAccount/closeTokenAccount.swift
+++ b/Sources/Solana/Actions/closeTokenAccount/closeTokenAccount.swift
@@ -26,3 +26,21 @@ extension Action {
         }
     }
 }
+
+extension ActionTemplates {
+    public struct CloseTokenAccountAction: ActionTemplate {
+        public init(account: Account?, tokenPubkey: String) {
+            self.account = account
+            self.tokenPubkey = tokenPubkey
+        }
+
+        public typealias Success = TransactionID
+
+        public let account: Account?
+        public let tokenPubkey: String
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<Success, Error>) -> Void) {
+            actionClass.closeTokenAccount(account: account, tokenPubkey: tokenPubkey, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
+++ b/Sources/Solana/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
@@ -89,3 +89,43 @@ extension Action {
             }
     }
 }
+
+extension ActionTemplates {
+
+    public struct CreateAssociatedTokenAccountAction: ActionTemplate {
+        public init(owner: PublicKey, tokenMint: PublicKey, payer: Account?) {
+            self.owner = owner
+            self.tokenMint = tokenMint
+            self.payer = payer
+        }
+
+        public typealias Success = TransactionID
+        public let owner: PublicKey
+        public let tokenMint: PublicKey
+        public let payer: Account?
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<TransactionID, Error>) -> Void) {
+            actionClass.createAssociatedTokenAccount(
+                for: owner,
+                   tokenMint: tokenMint,
+                   payer: payer,
+                   onComplete: completion
+            )
+        }
+    }
+
+    public struct GetOrCreateAssociatedTokenAccountAction: ActionTemplate {
+        public init(owner: PublicKey, tokenMint: PublicKey) {
+            self.owner = owner
+            self.tokenMint = tokenMint
+        }
+
+        public typealias Success = (transactionId: TransactionID?, associatedTokenAddress: PublicKey)
+        public let owner: PublicKey
+        public let tokenMint: PublicKey
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<Success, Error>) -> Void) {
+            actionClass.getOrCreateAssociatedTokenAccount(owner: owner, tokenMint: tokenMint, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Sources/Solana/Actions/createTokenAccount/createTokenAccount.swift
@@ -102,3 +102,23 @@ extension Action {
         }
     }
 }
+
+extension ActionTemplates {
+    public struct GetCreatingTokenAccountFee: ActionTemplate {
+        public typealias Success = UInt64
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<UInt64, Error>) -> Void) {
+            actionClass.getCreatingTokenAccountFee(onComplete: completion)
+        }
+    }
+
+    public struct CreateTokenAccount: ActionTemplate {
+        public typealias Success = (signature: String, newPubkey: String)
+
+        public let mintAddress: String
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<(signature: String, newPubkey: String), Error>) -> Void) {
+            actionClass.createTokenAccount(mintAddress: mintAddress, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/findSPLTokenDestinationAddress/findSPLTokenDestinationAddress.swift
+++ b/Sources/Solana/Actions/findSPLTokenDestinationAddress/findSPLTokenDestinationAddress.swift
@@ -65,3 +65,20 @@ extension Action {
         }.run(onComplete)
     }
 }
+
+extension ActionTemplates {
+    public struct FindSPLTokenDestinationAddress: ActionTemplate {
+        public init(mintAddress: String, destinationAddress: String) {
+            self.mintAddress = mintAddress
+            self.destinationAddress = destinationAddress
+        }
+
+        public typealias Success = Action.SPLTokenDestinationAddress
+        public let mintAddress: String
+        public let destinationAddress: String
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<Action.SPLTokenDestinationAddress, Error>) -> Void) {
+            actionClass.findSPLTokenDestinationAddress(mintAddress: mintAddress, destinationAddress: destinationAddress, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/getMintData/getMintData.swift
+++ b/Sources/Solana/Actions/getMintData/getMintData.swift
@@ -48,3 +48,35 @@ public extension Action {
         }.run(onComplete)
     }
 }
+
+extension ActionTemplates {
+    public struct GetMintData: ActionTemplate {
+        public init(programId: PublicKey = .tokenProgramId, mintAddress: PublicKey) {
+            self.programId = programId
+            self.mintAddress = mintAddress
+        }
+
+        public typealias Success = Mint
+        public let programId: PublicKey
+        public let mintAddress: PublicKey
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<Mint, Error>) -> Void) {
+            actionClass.getMintData(mintAddress: mintAddress, programId: programId, onComplete: completion)
+        }
+    }
+
+    public struct GetMultipleMintData: ActionTemplate {
+        public init(programId: PublicKey = .tokenProgramId, mintAddresses: [PublicKey]) {
+            self.programId = programId
+            self.mintAddresses = mintAddresses
+        }
+
+        public typealias Success = [PublicKey: Mint]
+        public let programId: PublicKey
+        public let mintAddresses: [PublicKey]
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<[PublicKey : Mint], Error>) -> Void) {
+            actionClass.getMultipleMintDatas(mintAddresses: mintAddresses, programId: programId, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/getPools/getPools.swift
+++ b/Sources/Solana/Actions/getPools/getPools.swift
@@ -175,3 +175,29 @@ extension Array {
         }
     }
 }
+
+extension ActionTemplates {
+    public struct GetPools: ActionTemplate {
+        public init(swapProgramId: String) {
+            self.swapProgramId = swapProgramId
+        }
+
+        public typealias Success =  [Pool]
+
+        public let swapProgramId: String
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<[Pool], Error>) -> Void) {
+            actionClass.getPools(swapProgramId: swapProgramId, onComplete: completion)
+        }
+    }
+
+    public struct GetSwapPools: ActionTemplate {
+        public init() { }
+
+        public typealias Success = [Pool]
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<[Pool], Error>) -> Void) {
+            actionClass.getSwapPools(onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Sources/Solana/Actions/getTokenWallets/getTokenWallets.swift
@@ -36,3 +36,18 @@ extension Action {
         }.run(onComplete)
     }
 }
+
+extension ActionTemplates {
+    public struct GetTokenWallets: ActionTemplate {
+        public init(account: String? = nil) {
+            self.account = account
+        }
+
+        public typealias Success = [Wallet]
+        public let account: String?
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<[Wallet], Error>) -> Void) {
+            actionClass.getTokenWallets(account: account, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/sendSOL/sendSOL.swift
+++ b/Sources/Solana/Actions/sendSOL/sendSOL.swift
@@ -64,3 +64,20 @@ extension Action {
 
     }
 }
+
+extension ActionTemplates {
+    public struct SendSOL: ActionTemplate {
+        public init(amount: UInt64, destination: String) {
+            self.amount = amount
+            self.destination = destination
+        }
+
+        public typealias Success = TransactionID
+        public let amount: UInt64
+        public let destination: String
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<TransactionID, Error>) -> Void) {
+            actionClass.sendSOL(to: destination, amount: amount, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Sources/Solana/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -71,3 +71,19 @@ extension Action {
         }.run(onComplete)
     }
 }
+
+extension ActionTemplates {
+    public struct SendSPLTokens: ActionTemplate {
+        public let mintAddress: String
+        public let fromPublicKey: String
+        public let destinationAddress: String
+        public let amount: UInt64
+        public let decimals: Decimals
+
+        public typealias Success = TransactionID
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<TransactionID, Error>) -> Void) {
+            actionClass.sendSPLTokens(mintAddress: mintAddress, decimals: decimals, from: fromPublicKey, to: destinationAddress, amount: amount, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
+++ b/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
@@ -44,3 +44,25 @@ extension Action {
         }
     }
 }
+
+extension ActionTemplates {
+    public struct SerializeTransaction: ActionTemplate {
+        public init(instructions: [TransactionInstruction], signers: [Account], recentBlockhash: String? = nil, feePayer: PublicKey? = nil) {
+            self.instructions = instructions
+            self.recentBlockhash = recentBlockhash
+            self.signers = signers
+            self.feePayer = feePayer
+        }
+
+        public typealias Success = String
+
+        public let instructions: [TransactionInstruction]
+        public let recentBlockhash: String?
+        public let signers: [Account]
+        public let feePayer: PublicKey?
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<String, Error>) -> Void) {
+            actionClass.serializeTransaction(instructions: instructions, recentBlockhash: recentBlockhash, signers: signers, feePayer: feePayer, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Actions/swap/swap.swift
+++ b/Sources/Solana/Actions/swap/swap.swift
@@ -296,3 +296,65 @@ extension Action {
         return .success(newAccount)
     }
 }
+
+extension ActionTemplates {
+    public struct Swap: ActionTemplate {
+        public init(account: Account? = nil,
+                    pool: Pool? = nil,
+                    source: PublicKey,
+                    sourceMint: PublicKey,
+                    destination: PublicKey? = nil,
+                    destinationMint: PublicKey,
+                    slippage: Double,
+                    amount: UInt64) {
+            self.account = account
+            self.pool = pool
+            self.source = source
+            self.sourceMint = sourceMint
+            self.destination = destination
+            self.destinationMint = destinationMint
+            self.slippage = slippage
+            self.amount = amount
+        }
+
+        public let account: Account?// = nil
+        public let pool: Pool?// = nil
+        public let source: PublicKey
+        public let sourceMint: PublicKey
+        public let destination: PublicKey?// = nil
+        public let destinationMint: PublicKey
+        public let slippage: Double
+        public let amount: UInt64
+
+        public typealias Success = Action.SwapResponse
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<Action.SwapResponse, Error>) -> Void) {
+            actionClass.swap(account: account,
+                             pool: pool,
+                             source: source,
+                             sourceMint: sourceMint,
+                             destination: destination,
+                             destinationMint: destinationMint,
+                             slippage: slippage,
+                             amount: amount,
+                             onComplete: completion)
+        }
+    }
+
+    public struct GetAccountInfoData: ActionTemplate {
+        public init(account: String, tokenProgramId: PublicKey) {
+            self.account = account
+            self.tokenProgramId = tokenProgramId
+        }
+
+
+        public let account: String
+        public let tokenProgramId: PublicKey
+
+        public typealias Success = AccountInfo
+
+        public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<AccountInfo, Error>) -> Void) {
+            actionClass.getAccountInfoData(account: account, tokenProgramId: tokenProgramId, onComplete: completion)
+        }
+    }
+}


### PR DESCRIPTION
Hello, all!

This PR is for the "typed action template" system we've discussed a couple times. The idea is that, while the current formulation to perform transactions is relatively convenient generally, if you're working with another paradigm, like Rx, Combine, or Swift's new structured concurrency, then the callback format can be inconvenient, and rewriting custom implementations that shim each and every action that can be performed is not only arduous, but ultimately somewhat self-defeating.

So in this PR, I'm suggesting the addition of (optional — you can still have actions without writing one, of course!) "Action Templates" — struct-based versions of the instructions to perform a given action that you can hand directly to the `Action` class to perform instead of calling a method it owns. 

I've gone through a bunch of different iterations of what this could look like, but eventually, I concluded it's probably best just to keep this simple. 

In practice, here's how that looks, using a completion handler:

```swift
let action = Action(...) // configure the "Action" class exactly as you would now
let request = ActionTemplates.GetTokenWallets(...) // Build a request with the ActionTemplate representing what you want to do.
action.perform(request) { result in
    // perform any actions you want here, just like berfore
}
```

But the _real_ power here, and the reason I think this is important to do, is in the fact that this will prevent us from writing dozens of identical-looking variations on each action in the API in each tool. So instead of writing dozens of Combine implementations, we can write one extension, which will support all the current _and future_ actions:

```swift
public extension Action {
   func publisher<T: ActionTemplate>(for actionTemplate: T) -> AnyPublisher<T.Success, Error> {
            Future<T.Success, Error> { promise in
                self.perform(actionTemplate) { promise($0) }
            }.eraseToAnyPublisher()
    }
}
```

And supporting structured concurrency is similarly straightforward:

```swift
public extension Action {
    func perform<T: ActionTemplate>(_ actionTemplate: T) async throws -> T.Success {
        try await withCheckedThrowingContinuation { continuation in
            perform(actionTemplate) { continuation.resume(with: $0)}
        }
    }
}
```

Rx, being nearly identical to these two except the addition of imperatively building a disposable, is left as an exercise for the reader :P. 

I think introducing a system like this will be crucial to the longevity of the APIs here, and it will allow us to split out dependencies on things like Combine, Rx, and Swift 5.5/iOS 15 without having to write hundreds of lines in the packages to support them.