### PR TITLE
Migrate NetworkingRouter to protocol for integration test use

### DIFF
--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -16,9 +16,9 @@ public enum RPCError: Error {
     case retry
 }
 
-public class NetworkingRouter {
+public class NetworkingRouter: SolanaRouter {
 
-    let endpoint: RPCEndpoint
+    public let endpoint: RPCEndpoint
     private let urlSession: URLSession
     public init(endpoint: RPCEndpoint, session: URLSession = .shared) {
         self.endpoint = endpoint

--- a/Sources/Solana/Networking/Router/SolanaRouter.swift
+++ b/Sources/Solana/Networking/Router/SolanaRouter.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/**
+ An object that determins how network requests are handled in use of the Solana tools.
+
+ Most use cases can prefer `NetworkingRouter` for daily us. Conform to this with a cusstom implementation to create local integration test tooling.
+ */
+public protocol SolanaRouter {
+    func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable
+
+    var endpoint: RPCEndpoint  { get }
+}

--- a/Sources/Solana/Networking/Router/SolanaRouter.swift
+++ b/Sources/Solana/Networking/Router/SolanaRouter.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  An object that determins how network requests are handled in use of the Solana tools.
 
- Most use cases can prefer `NetworkingRouter` for daily us. Conform to this with a cusstom implementation to create local integration test tooling.
+ Most use cases can prefer `NetworkingRouter` for daily use. Conform to this with a cusstom implementation to create local integration test tooling.
  */
 public protocol SolanaRouter {
     func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable

--- a/Sources/Solana/Solana.swift
+++ b/Sources/Solana/Solana.swift
@@ -38,11 +38,11 @@ public class Api {
 
 public class Action {
     internal let api: Api
-    internal let router: NetworkingRouter
+    internal let router: SolanaRouter
     internal let auth: SolanaAccountStorage
     internal let supportedTokens: [Token]
 
-    public init(api: Api, router: NetworkingRouter, auth: SolanaAccountStorage, supportedTokens: [Token]) {
+    public init(api: Api, router: SolanaRouter, auth: SolanaAccountStorage, supportedTokens: [Token]) {
         self.router = router
         self.auth = auth
         self.supportedTokens = supportedTokens


### PR DESCRIPTION
This PR migrates `NetworkingRouter` from being just a class to being a conformer to the protocol `SolanaRouter`, which gets used by the `Solana` object — this should make it far easier for users to inject custom testing logic into their apps without having to directly subclass and learn the internal implementation details of `NetworkingRouter`.