### PR TITLE
Bump macOS build step on GH Actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR bumps the build and test step to use the new macOS 11 GH actions option, which will enable us to check against other Swift features in the future, as well as (more importantly for now) just putting us in step with the platform and up to date with the way other open source projects are configuring themselves.

Since the Swift requirements are not changing, we should not begin using any new features in the frameworks, but this seems like a good maintenance change.