### PR TITLE
Do not require decimals when transfering SPL tokens

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "secp256k1.swift",
+        "package": "secp256k1",
         "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
         "state": {
           "branch": null,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "package": "tweetnacl-swiftwrap",
+        "package": "TweetNacl",
         "repositoryURL": "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git",
         "state": {
           "branch": null,

--- a/Sources/Solana/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Sources/Solana/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -3,7 +3,6 @@ import Foundation
 extension Action {
     public func sendSPLTokens(
         mintAddress: String,
-        decimals: Decimals,
         from fromPublicKey: String,
         to destinationAddress: String,
         amount: UInt64,
@@ -78,12 +77,11 @@ extension ActionTemplates {
         public let fromPublicKey: String
         public let destinationAddress: String
         public let amount: UInt64
-        public let decimals: Decimals
 
         public typealias Success = TransactionID
 
         public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<TransactionID, Error>) -> Void) {
-            actionClass.sendSPLTokens(mintAddress: mintAddress, decimals: decimals, from: fromPublicKey, to: destinationAddress, amount: amount, onComplete: completion)
+            actionClass.sendSPLTokens(mintAddress: mintAddress, from: fromPublicKey, to: destinationAddress, amount: amount, onComplete: completion)
         }
     }
 }

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
@@ -35,7 +35,6 @@ extension Action {
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
             self?.sendSPLTokens(mintAddress: mintAddress,
-                                decimals: decimals,
                                 from: fromPublicKey,
                                 to: destinationAddress,
                                 amount: amount) {


### PR DESCRIPTION
It's not needed so we shouldn't require it. 