### PR TITLE
Feature/send sol allow unfunded recipient

### DIFF
--- a/Sources/Solana/Actions/sendSOL/sendSOL.swift
+++ b/Sources/Solana/Actions/sendSOL/sendSOL.swift
@@ -4,6 +4,7 @@ extension Action {
     public func sendSOL(
         to destination: String,
         amount: UInt64,
+        allowUnfundedRecipient: Bool = false,
         onComplete: @escaping ((Result<TransactionID, Error>) -> Void)
     ) {
         guard let account = try? self.auth.account.get() else {
@@ -18,50 +19,63 @@ extension Action {
         }
 
         // check
-        self.api.getAccountInfo(account: destination, decodedTo: EmptyInfo.self) { resultInfo in
+        if allowUnfundedRecipient {
+            serializeAndSend(from: fromPublicKey, to: destination, amount: amount, signer: account, onComplete: onComplete)
+        } else {
+            self.api.getAccountInfo(account: destination, decodedTo: EmptyInfo.self) { resultInfo in
+                if case Result.failure( let error) = resultInfo {
+                    if let solanaError = error as? SolanaError,
+                       case SolanaError.couldNotRetriveAccountInfo = solanaError {
+                        // let request through
+                    } else {
+                        onComplete(.failure(error))
+                        return
+                    }
+                }
 
-            if case Result.failure( let error) = resultInfo {
-                if let solanaError = error as? SolanaError,
-                   case SolanaError.couldNotRetriveAccountInfo = solanaError {
-                    // let request through
-                } else {
-                    onComplete(.failure(error))
+                guard case Result.success(let info) = resultInfo else {
+                    onComplete(.failure(SolanaError.couldNotRetriveAccountInfo))
                     return
                 }
-            }
 
-            guard case Result.success(let info) = resultInfo else {
-                onComplete(.failure(SolanaError.couldNotRetriveAccountInfo))
-                return
-            }
-
-            guard info.owner == PublicKey.programId.base58EncodedString else {
-                onComplete(.failure(SolanaError.other("Invalid account info")))
-                return
-            }
-            guard let to = PublicKey(string: destination) else {
-                onComplete(.failure(SolanaError.invalidPublicKey))
-                return
-            }
-
-            let instruction = SystemProgram.transferInstruction(
-                from: fromPublicKey,
-                to: to,
-                lamports: amount
-            )
-            self.serializeAndSendWithFee(
-                instructions: [instruction],
-                signers: [account]
-            ) {
-                switch $0 {
-                case .success(let transaction):
-                    onComplete(.success(transaction))
-                case .failure(let error):
-                    onComplete(.failure(error))
+                guard info.owner == PublicKey.programId.base58EncodedString else {
+                    onComplete(.failure(SolanaError.other("Invalid account info")))
+                    return
                 }
+
+                self.serializeAndSend(from: fromPublicKey, to: destination, amount: amount, signer: account, onComplete: onComplete)
             }
         }
+    }
 
+    fileprivate func serializeAndSend(
+        from fromPublicKey: PublicKey,
+        to destination: String,
+        amount: UInt64,
+        signer: Account,
+        onComplete: @escaping ((Result<TransactionID, Error>) -> Void)
+    ) {
+        guard let to = PublicKey(string: destination) else {
+            onComplete(.failure(SolanaError.invalidPublicKey))
+            return
+        }
+
+        let instruction = SystemProgram.transferInstruction(
+            from: fromPublicKey,
+            to: to,
+            lamports: amount
+        )
+        self.serializeAndSendWithFee(
+            instructions: [instruction],
+            signers: [signer]
+        ) {
+            switch $0 {
+            case .success(let transaction):
+                onComplete(.success(transaction))
+            case .failure(let error):
+                onComplete(.failure(error))
+            }
+        }
     }
 }
 

--- a/Sources/Solana/Extensions/PublicKey/PublicKey+AssociatedTokenProgram.swift
+++ b/Sources/Solana/Extensions/PublicKey/PublicKey+AssociatedTokenProgram.swift
@@ -34,10 +34,9 @@ extension PublicKey {
     ) -> Result<(Self, UInt8), Error> {
         for nonce in stride(from: UInt8(255), to: 0, by: -1) {
             let seedsWithNonce = seeds + [Data([nonce])]
-            return createProgramAddress(
-                seeds: seedsWithNonce,
-                programId: programId
-            ).map {($0, nonce) }
+            if case .success(let publicKey) = createProgramAddress(seeds: seedsWithNonce, programId: programId) {
+                return .success((publicKey, nonce))
+            }
         }
         return .failure(SolanaError.notFoundProgramAddress)
     }


### PR DESCRIPTION
Hello Arturo!

I've added a boolean flag similar to `--allow-unfunded-recipient` of Solana CLI to fund the creation of the account by sending SOL to it. Please review, if there's anything you'd want me to tweak — let me know.

Thanks