### PR TITLE
Remove the default auth from the Solana.

### DIFF
--- a/Sources/Solana/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Sources/Solana/Actions/getTokenWallets/getTokenWallets.swift
@@ -1,11 +1,7 @@
 import Foundation
 
 extension Action {
-    public func getTokenWallets(account: String? = nil, onComplete: @escaping ((Result<[Wallet], Error>) -> Void)) {
-
-        guard let account = try? account ?? auth.account.get().publicKey.base58EncodedString else {
-            return onComplete(.failure(SolanaError.unauthorized))
-        }
+    public func getTokenWallets(account: String, onComplete: @escaping ((Result<[Wallet], Error>) -> Void)) {
 
         let configs = RequestConfiguration(commitment: "recent", encoding: "jsonParsed")
 
@@ -27,12 +23,12 @@ extension Action {
 
 extension ActionTemplates {
     public struct GetTokenWallets: ActionTemplate {
-        public init(account: String? = nil) {
+        public init(account: String) {
             self.account = account
         }
 
         public typealias Success = [Wallet]
-        public let account: String?
+        public let account: String
 
         public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<[Wallet], Error>) -> Void) {
             actionClass.getTokenWallets(account: account, onComplete: completion)

--- a/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
+++ b/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
@@ -5,14 +5,9 @@ extension Action {
         instructions: [TransactionInstruction],
         recentBlockhash: String? = nil,
         signers: [Account],
-        feePayer: PublicKey? = nil,
+        feePayer: PublicKey,
         onComplete: @escaping ((Result<String, Error>) -> Void)
     ) {
-
-        guard let feePayer = try? feePayer ?? auth.account.get().publicKey else {
-            onComplete(.failure(SolanaError.invalidRequest(reason: "Fee-payer not found")))
-            return
-        }
 
         let getRecentBlockhashRequest: (Result<String, Error>) -> Void = { result in
             switch result {
@@ -47,7 +42,7 @@ extension Action {
 
 extension ActionTemplates {
     public struct SerializeTransaction: ActionTemplate {
-        public init(instructions: [TransactionInstruction], signers: [Account], recentBlockhash: String? = nil, feePayer: PublicKey? = nil) {
+        public init(instructions: [TransactionInstruction], signers: [Account], recentBlockhash: String? = nil, feePayer: PublicKey) {
             self.instructions = instructions
             self.recentBlockhash = recentBlockhash
             self.signers = signers
@@ -59,7 +54,7 @@ extension ActionTemplates {
         public let instructions: [TransactionInstruction]
         public let recentBlockhash: String?
         public let signers: [Account]
-        public let feePayer: PublicKey?
+        public let feePayer: PublicKey
 
         public func perform(withConfigurationFrom actionClass: Action, completion: @escaping (Result<String, Error>) -> Void) {
             actionClass.serializeTransaction(instructions: instructions, recentBlockhash: recentBlockhash, signers: signers, feePayer: feePayer, onComplete: completion)

--- a/Sources/Solana/Actions/swap/swap.swift
+++ b/Sources/Solana/Actions/swap/swap.swift
@@ -8,7 +8,7 @@ extension Action {
     }
 
     public func swap(
-        account: Account? = nil,
+        account: Account,
         pool: Pool? = nil,
         source: PublicKey,
         sourceMint: PublicKey,
@@ -18,11 +18,7 @@ extension Action {
         amount: UInt64,
         onComplete: @escaping(Result<SwapResponse, Error>) -> Void
     ) {
-        // verify account
-        guard let owner = try? account ?? auth.account.get() else {
-             onComplete(.failure(SolanaError.unauthorized))
-            return
-        }
+        let owner = account
 
         // reduce pools
         var getPoolRequest: ContResult<Pool, Error>
@@ -177,7 +173,8 @@ extension Action {
             return ContResult<String, Error>.init { cb in
                 self.serializeAndSendWithFee(
                     instructions: instructions + cleanupInstructions,
-                    signers: signers
+                    signers: signers,
+                    feePayer: account.publicKey
                 ) {
                     cb($0)
                 }
@@ -299,7 +296,7 @@ extension Action {
 
 extension ActionTemplates {
     public struct Swap: ActionTemplate {
-        public init(account: Account? = nil,
+        public init(account: Account,
                     pool: Pool? = nil,
                     source: PublicKey,
                     sourceMint: PublicKey,
@@ -317,7 +314,7 @@ extension ActionTemplates {
             self.amount = amount
         }
 
-        public let account: Account?// = nil
+        public let account: Account
         public let pool: Pool?// = nil
         public let source: PublicKey
         public let sourceMint: PublicKey

--- a/Sources/Solana/Api/getBalance/getBalance.swift
+++ b/Sources/Solana/Api/getBalance/getBalance.swift
@@ -1,13 +1,7 @@
 import Foundation
 
 public extension Api {
-    func getBalance(account: String? = nil, commitment: Commitment? = nil, onComplete: @escaping(Result<UInt64, Error>) -> Void) {
-
-        guard let account = try? account ?? auth.account.get().publicKey.base58EncodedString
-        else {
-            onComplete(.failure(SolanaError.unauthorized))
-            return
-        }
+    func getBalance(account: String, commitment: Commitment? = nil, onComplete: @escaping(Result<UInt64, Error>) -> Void) {
         router.request(parameters: [account, RequestConfiguration(commitment: commitment)]) { (result: Result<Rpc<UInt64?>, Error>) in
             switch result {
             case .success(let rpc):
@@ -25,12 +19,12 @@ public extension Api {
 
 public extension ApiTemplates {
     struct GetBalance: ApiTemplate {
-        public init(account: String? = nil, commitment: Commitment? = nil) {
+        public init(account: String, commitment: Commitment? = nil) {
             self.account = account
             self.commitment = commitment
         }
         
-        public let account: String?
+        public let account: String
         public let commitment: Commitment?
         
         public typealias Success = UInt64

--- a/Sources/Solana/Solana.swift
+++ b/Sources/Solana/Solana.swift
@@ -9,33 +9,28 @@ public protocol SolanaAccountStorage {
 public class Solana {
     let router: NetworkingRouter
     public let socket: SolanaSocket
-    public let auth: SolanaAccountStorage
     public let api: Api
     public let action: Action
     public let tokens: TokenInfoProvider
 
     public init(
         router: NetworkingRouter,
-        accountStorage: SolanaAccountStorage,
         tokenProvider: TokenInfoProvider = EmptyInfoTokenProvider()
     ) {
         self.router = router
-        self.auth = accountStorage
         self.socket = SolanaSocket(endpoint: router.endpoint)
         self.tokens = tokenProvider
-        self.api = Api(router: router, auth: accountStorage, supportedTokens: self.tokens.supportedTokens)
-        self.action = Action(api: self.api, router: router, auth: accountStorage, supportedTokens: self.tokens.supportedTokens)
+        self.api = Api(router: router, supportedTokens: self.tokens.supportedTokens)
+        self.action = Action(api: self.api, router: router, supportedTokens: self.tokens.supportedTokens)
     }
 }
 
 public class Api {
     internal let router: NetworkingRouter
-    public let auth: SolanaAccountStorage
     internal let supportedTokens: [Token]
 
-    public init(router: NetworkingRouter, auth: SolanaAccountStorage, supportedTokens: [Token]) {
+    public init(router: NetworkingRouter, supportedTokens: [Token]) {
         self.router = router
-        self.auth = auth
         self.supportedTokens = supportedTokens
     }
 }
@@ -43,12 +38,10 @@ public class Api {
 public class Action {
     internal let api: Api
     internal let router: SolanaRouter
-    internal let auth: SolanaAccountStorage
     internal let supportedTokens: [Token]
 
-    public init(api: Api, router: SolanaRouter, auth: SolanaAccountStorage, supportedTokens: [Token]) {
+    public init(api: Api, router: SolanaRouter, supportedTokens: [Token]) {
         self.router = router
-        self.auth = auth
         self.supportedTokens = supportedTokens
         self.api = api
     }

--- a/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/closeTokenAccount/closeTokenAccount.swift
@@ -4,13 +4,12 @@ import XCTest
 class closeTokenAccount: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solanaSDK: Solana!
-    var account: Account { try! solanaSDK.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solanaSDK.auth.save(account).get()
+        solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testCloseAccountInstruction() {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssociatedTokenAccount.swift
@@ -4,24 +4,23 @@ import Solana
 class createAssociatedTokenAccount: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testGetOrCreateAssociatedTokenAccount() {
         let tokenMint = PublicKey(string: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!
-        let account: (transactionId: TransactionID?, associatedTokenAddress: PublicKey)? = try! solana.action.getOrCreateAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint)?.get()
+        let account: (transactionId: TransactionID?, associatedTokenAddress: PublicKey)? = try! solana.action.getOrCreateAssociatedTokenAccount(for: account.publicKey, tokenMint: tokenMint, payer: account)?.get()
         XCTAssertNotNil(account)
     }
     
     func testFailCreateAssociatedTokenAccountItExisted() {
         let tokenMint = PublicKey(string: "2tWC4JAdL4AxEFJySziYJfsAnW2MHKRo98vbAPiRDSk8")!
-        XCTAssertThrowsError(try (solana.action.createAssociatedTokenAccount(for: try! solana.auth.account.get().publicKey, tokenMint: tokenMint)?.get() as TransactionID?))
+        XCTAssertThrowsError(try (solana.action.createAssociatedTokenAccount(for: account.publicKey, tokenMint: tokenMint, payer: account)?.get() as TransactionID?))
     }
 
     func testFindAssociatedTokenAddress() {

--- a/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssosiatedTokenAccount+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/createAssociatedTokenAccount/createAssosiatedTokenAccount+SimpleLock.swift
@@ -11,12 +11,13 @@ import Solana
 extension Action {
     public func getOrCreateAssociatedTokenAccount(
         for owner: PublicKey,
-        tokenMint: PublicKey
+        tokenMint: PublicKey,
+        payer: Account
     ) -> Result<(transactionId: TransactionID?, associatedTokenAddress: PublicKey), Error>? {
         var info: Result<(transactionId: TransactionID?, associatedTokenAddress: PublicKey), Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
-            self?.getOrCreateAssociatedTokenAccount(owner: owner, tokenMint: tokenMint) {
+            self?.getOrCreateAssociatedTokenAccount(owner: owner, tokenMint: tokenMint, payer: payer) {
                 info = $0
                 lock.stop()
             }
@@ -28,7 +29,7 @@ extension Action {
     public func createAssociatedTokenAccount(
         for owner: PublicKey,
         tokenMint: PublicKey,
-        payer: Account? = nil
+        payer: Account
     ) -> Result<TransactionID, Error>? {
         var transactionId: Result<TransactionID, Error>?
         let lock = RunLoopSimpleLock()

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount+SimpleLock.swift
@@ -9,12 +9,13 @@ import Solana
 
 extension Action {
     public func createTokenAccount(
-        mintAddress: String
+        mintAddress: String,
+        payer: Account
     ) -> Result<(signature: String, newPubkey: String), Error>? {
         var transactionResult: Result<(signature: String, newPubkey: String), Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch {
-            self.createTokenAccount(mintAddress: mintAddress) {
+            self.createTokenAccount(mintAddress: mintAddress, payer: payer) {
                 transactionResult = $0
                 lock.stop()
             }

--- a/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
+++ b/Tests/SolanaTests/Actions/createTokenAccount/createTokenAccount.swift
@@ -4,18 +4,17 @@ import Solana
 class createTokenAccount: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testCreateTokenAccount() {
         let mintAddress = "6AUM4fSvCAxCugrbJPFxTqYFp9r3axYx973yoSyzDYVH"
-        let account: (signature: String, newPubkey: String)? = try! solana.action.createTokenAccount( mintAddress: mintAddress)?.get()
+        let account: (signature: String, newPubkey: String)? = try! solana.action.createTokenAccount( mintAddress: mintAddress, payer: self.account)?.get()
         XCTAssertNotNil(account)
     }
     

--- a/Tests/SolanaTests/Actions/getMintData/getMintData.swift
+++ b/Tests/SolanaTests/Actions/getMintData/getMintData.swift
@@ -4,13 +4,12 @@ import XCTest
 class getMintData: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testGetMintData() {

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets+SimpleLock.swift
@@ -9,7 +9,7 @@ import Foundation
 import Solana
 
 extension Action {
-    func getTokenWallets(account: String? = nil) -> Result<[Wallet], Error>? {
+    func getTokenWallets(account: String) -> Result<[Wallet], Error>? {
         var walletResult: Result<[Wallet], Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in

--- a/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
+++ b/Tests/SolanaTests/Actions/getTokenWallets/getTokenWallets.swift
@@ -4,13 +4,12 @@ import Solana
 class getTokenWallets: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .getWallets
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testsGetTokenWalletsParsing() {
@@ -22,7 +21,7 @@ class getTokenWallets: XCTestCase {
     }
     
     func testsGetTokenWallets() {
-        let wallets = try? solana.action.getTokenWallets()?.get()
+        let wallets = try? solana.action.getTokenWallets(account: account.publicKey.base58EncodedString)?.get()
         XCTAssertNotNil(wallets)
         XCTAssertNotEqual(wallets!.count, 0)
     }

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL+SimpleLock.swift
@@ -9,7 +9,7 @@ import Foundation
 import Solana
 
 extension Api {
-    func getBalance(account: String? = nil, commitment: Commitment? = nil) -> Result<UInt64, Error>? {
+    func getBalance(account: String, commitment: Commitment? = nil) -> Result<UInt64, Error>? {
         var balance: Result<UInt64, Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
@@ -27,12 +27,13 @@ extension Action {
 
     func sendSOL(
         to destination: String,
-        amount: UInt64
+        amount: UInt64,
+        from: Account
     ) -> Result<TransactionID, Error>? {
         var transaction: Result<TransactionID, Error>?
         let lock = RunLoopSimpleLock()
         lock.dispatch { [weak self] in
-            self?.sendSOL(to: destination, amount: amount) {
+            self?.sendSOL(to: destination, from: from, amount: amount) {
                 transaction = $0
                 lock.stop()
             }

--- a/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
+++ b/Tests/SolanaTests/Actions/sendSOL/sendSOL.swift
@@ -4,24 +4,24 @@ import Solana
 class sendSOL: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
-        let wallet: TestsWallet = .getWallets
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        let wallet: TestsWallet = .devnet
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)! // 5Zzguz4NsSRFxGkHfM4FmsFpGZiCDtY72zH2jzMcqkJx
     }
     
     func testSendSOLFromBalance() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance()?.get()
+        let balance = try! solana.api.getBalance(account: account.publicKey.base58EncodedString)?.get()
         XCTAssertNotNil(balance)
 
         let transactionId = try! solana.action.sendSOL(
             to: toPublicKey,
-            amount: balance!/10
+            amount: balance!/10,
+            from: account
         )?.get()
         XCTAssertNotNil(transactionId)
     }
@@ -29,7 +29,8 @@ class sendSOL: XCTestCase {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
         let transactionId = try! solana.action.sendSOL(
             to: toPublicKey,
-            amount: 0.001.toLamport(decimals: 9)
+            amount: 0.001.toLamport(decimals: 9),
+            from: account
         )?.get()
         XCTAssertNotNil(transactionId)
     }
@@ -37,14 +38,16 @@ class sendSOL: XCTestCase {
         let toPublicKey = "XX"
         XCTAssertThrowsError(try solana.action.sendSOL(
             to: toPublicKey,
-            amount: 0.001.toLamport(decimals: 9)
+            amount: 0.001.toLamport(decimals: 9),
+            from: account
         )?.get())
     }
     func testSendSOLBigAmmount() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
         XCTAssertThrowsError(try solana.action.sendSOL(
             to: toPublicKey,
-            amount: 9223372036854775808
+            amount: 9223372036854775808,
+            from: account
         )?.get())
     }
 }

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens+SimpleLock.swift
@@ -29,7 +29,8 @@ extension Action {
         decimals: Decimals,
         from fromPublicKey: String,
         to destinationAddress: String,
-        amount: UInt64
+        amount: UInt64,
+        payer: Account
     ) -> Result<TransactionID, Error>? {
         var transaction: Result<TransactionID, Error>?
         let lock = RunLoopSimpleLock()
@@ -37,7 +38,8 @@ extension Action {
             self?.sendSPLTokens(mintAddress: mintAddress,
                                 from: fromPublicKey,
                                 to: destinationAddress,
-                                amount: amount) {
+                                amount: amount,
+                                payer: payer) {
                 transaction = $0
                 lock.stop()
             }

--- a/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
+++ b/Tests/SolanaTests/Actions/sendSPLTokens/sendSPLTokens.swift
@@ -4,13 +4,12 @@ import Solana
 class sendSPLTokens: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
         _ = try solana.api.requestAirdrop(account: account.publicKey.base58EncodedString, lamports: 100.toLamport(decimals: 9))?.get()
     }
     
@@ -24,7 +23,8 @@ class sendSPLTokens: XCTestCase {
             decimals: 5,
             from: source,
             to: destination,
-            amount: Double(0.001).toLamport(decimals: 5)
+            amount: Double(0.001).toLamport(decimals: 5),
+            payer: account
         )?.get()
         XCTAssertNotNil(transactionId)
         
@@ -33,7 +33,8 @@ class sendSPLTokens: XCTestCase {
             decimals: 5,
             from: destination,
             to: source,
-            amount: Double(0.001).toLamport(decimals: 5)
+            amount: Double(0.001).toLamport(decimals: 5),
+            payer: account
         )?.get()
         XCTAssertNotNil(transactionIdB)
     }

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee+SimpleLock.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee+SimpleLock.swift
@@ -12,6 +12,7 @@ extension Action {
         instructions: [TransactionInstruction],
         recentBlockhash: String? = nil,
         signers: [Account],
+        feePayer: PublicKey,
         maxAttemps: Int = 3,
         numberOfTries: Int = 0
     ) -> Result<String, Error>? {
@@ -21,6 +22,7 @@ extension Action {
             self?.serializeAndSendWithFee(instructions: instructions,
                                           recentBlockhash: recentBlockhash,
                                           signers: signers,
+                                          feePayer: feePayer,
                                           maxAttemps: maxAttemps,
                                           numberOfTries: numberOfTries) {
                 transaction = $0
@@ -35,6 +37,7 @@ extension Action {
         instructions: [TransactionInstruction],
         recentBlockhash: String? = nil,
         signers: [Account],
+        feePayer: PublicKey,
         maxAttemps: Int = 3,
         numberOfTries: Int = 0
     ) -> Result<String, Error>? {
@@ -44,6 +47,7 @@ extension Action {
             self?.serializeAndSendWithFeeSimulation(instructions: instructions,
                                                     recentBlockhash: recentBlockhash,
                                                     signers: signers,
+                                                    feePayer: feePayer,
                                                     maxAttemps: maxAttemps,
                                                     numberOfTries: numberOfTries) {
                 transaction = $0

--- a/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
+++ b/Tests/SolanaTests/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
@@ -4,19 +4,18 @@ import XCTest
 class serializeAndSendWithFee: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     func testSimulationSerializeAndSend() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance()?.get()
+        let balance = try! solana.api.getBalance(account: account.publicKey.base58EncodedString)?.get()
         XCTAssertNotNil(balance)
 
         let instruction = SystemProgram.transferInstruction(
@@ -25,14 +24,14 @@ class serializeAndSendWithFee: XCTestCase {
             lamports: 0.001.toLamport(decimals: 9)
         )
         
-        let transactionId = try! solana.action.serializeAndSendWithFeeSimulation(instructions: [instruction], signers: [account])?.get()
+        let transactionId = try! solana.action.serializeAndSendWithFeeSimulation(instructions: [instruction], signers: [account], feePayer: account.publicKey)?.get()
         XCTAssertNotNil(transactionId)
     }
     
     func testSerializeAndSend() {
         let toPublicKey = "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG"
 
-        let balance = try! solana.api.getBalance()?.get()
+        let balance = try! solana.api.getBalance(account: account.publicKey.base58EncodedString)?.get()
         XCTAssertNotNil(balance)
 
         let instruction = SystemProgram.transferInstruction(
@@ -41,7 +40,7 @@ class serializeAndSendWithFee: XCTestCase {
             lamports: 0.001.toLamport(decimals: 9)
         )
         
-        let transactionId = try! solana.action.serializeAndSendWithFee( instructions: [instruction], signers: [account])?.get()
+        let transactionId = try! solana.action.serializeAndSendWithFee( instructions: [instruction], signers: [account], feePayer: account.publicKey)?.get()
         XCTAssertNotNil(transactionId)
     }
     

--- a/Tests/SolanaTests/Actions/swap/swap.swift
+++ b/Tests/SolanaTests/Actions/swap/swap.swift
@@ -4,14 +4,13 @@ import XCTest
 class swap: XCTestCase {
     var endpoint = RPCEndpoint.devnetSolana
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
     let publicKey = PublicKey(string: "11111111111111111111111111111111")!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     /*func testSwapToken() {

--- a/Tests/SolanaTests/Api/Methods.swift
+++ b/Tests/SolanaTests/Api/Methods.swift
@@ -4,13 +4,12 @@ import XCTest
 class Methods: XCTestCase {
     var endpoint = RPCEndpoint.devnetGenesysGo
     var solana: Solana!
-    var account: Account { try! solana.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solana = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage())
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solana.api.auth.save(account).get()
+        solana = Solana(router: NetworkingRouter(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
 
     func testGetAccountInfo() {
@@ -73,9 +72,9 @@ class Methods: XCTestCase {
         XCTAssertEqual(result?.count, 4)
     }
     func testGetConfirmedTransaction() {
-        let transaction = try! solana.api.getConfirmedTransaction(transactionSignature: "4fzLXJdrtokJsLESKtvVxS5q2u7mcQEbjMZXZxbiYXUSaP9CJV4kLZak6SzSLCCWMhZKvrvtPs9W36gaBbrMLmGT")?.get()
+        let transaction = try! solana.api.getConfirmedTransaction(transactionSignature: "4FoHNubE2XGc2ZNDrm1fBS3GZ33Q4qGHDiepLmsxUYmy2SV5nhyrwL3bcb3geohaVkaaw9gq6swSGsE7oXZKp1Y7")?.get()
         XCTAssertNotNil(transaction)
-        XCTAssertEqual(transaction!.blockTime, 1645332184)
+        XCTAssertEqual(transaction!.blockTime, 1649352445)
     }
     func testGetEpochInfo() {
         let epoch = try! solana.api.getEpochInfo()?.get()

--- a/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
+++ b/Tests/SolanaTests/TokenInfo/TokenInfoTests.swift
@@ -5,13 +5,12 @@ import XCTest
 class TokenInfoTests: XCTestCase {
     var endpoint = RPCEndpoint.mainnetBetaSolana
     var solanaSDK: Solana!
-    var account: Account { try! solanaSDK.auth.account.get() }
+    var account: Account!
 
     override func setUpWithError() throws {
         let wallet: TestsWallet = .devnet
-        solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint), accountStorage: InMemoryAccountStorage(), tokenProvider: ListTokenInfoProvider(endpoint: endpoint))
-        let account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
-        try solanaSDK.auth.save(account).get()
+        solanaSDK = Solana(router: NetworkingRouter(endpoint: endpoint), tokenProvider: ListTokenInfoProvider(endpoint: endpoint))
+        account = Account(phrase: wallet.testAccount.components(separatedBy: " "), network: endpoint.network)!
     }
     
     func testCloseAccountInstruction() {


### PR DESCRIPTION
Auth should not be a side effect. This PR allows to pass a payer and also not rely on a auth default storage for sdk