### PR TITLE
Add partialSigning and public Programs

### DIFF
--- a/Sources/Solana/Models/TransactionInstruction.swift
+++ b/Sources/Solana/Models/TransactionInstruction.swift
@@ -10,4 +10,10 @@ public struct TransactionInstruction: Decodable {
         self.programId = programId
         self.data = data.bytes
     }
+
+    public init(keys: [Account.Meta], programId: PublicKey, data: [UInt8]) {
+        self.keys = keys
+        self.programId = programId
+        self.data = data
+    }
 }

--- a/Sources/Solana/Programs/AssociatedTokenProgram.swift
+++ b/Sources/Solana/Programs/AssociatedTokenProgram.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct AssociatedTokenProgram {
     // MARK: - Interface
-    static func createAssociatedTokenAccountInstruction(
+    public static func createAssociatedTokenAccountInstruction(
         associatedProgramId: PublicKey = .splAssociatedTokenAccountProgramId,
         programId: PublicKey = .tokenProgramId,
         mint: PublicKey,

--- a/Sources/Solana/Programs/TokenProgram.swift
+++ b/Sources/Solana/Programs/TokenProgram.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct TokenProgram {
+public struct TokenProgram {
     // MARK: - Nested type
     private struct Index {
         static let initalizeMint: UInt8 = 0

--- a/Sources/Solana/Programs/TokenSwapProgram.swift
+++ b/Sources/Solana/Programs/TokenSwapProgram.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct TokenSwapProgram {
+public struct TokenSwapProgram {
     // MARK: - Nested type
     private enum Index: UInt8, BytesEncodable {
         case initialize = 0


### PR DESCRIPTION
Closes https://github.com/ajamaica/Solana.Swift/issues/175 and https://github.com/ajamaica/Solana.Swift/issues/174
Touches https://github.com/ajamaica/Solana.Swift/issues/148

See issues for more context.

- Mark all unspecified Programs and Program functions as public
- Add public version of TransactionInitializer initializer to support custom Transactions (see https://github.com/ajamaica/Solana.Swift/issues/148)
- Add public, standalone version of Transaction.partialSign

All of this is in line with existing JS and Kotlin implementations of the Solana library, with the exception that Kotlin does not yet support Transaction.partialSign, but it's in progress.